### PR TITLE
Implement instructor registration with user roles

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -10,13 +10,22 @@ with app.app_context():
     admin_login = os.getenv("ADMIN_LOGIN")
     admin_password = os.getenv("ADMIN_PASSWORD")
 
-    if not Uzytkownik.query.filter_by(login=admin_login).first():
+    admin_user = Uzytkownik.query.filter_by(login=admin_login).first()
+    if not admin_user:
         hashed = generate_password_hash(admin_password)
-        admin = Uzytkownik(login=admin_login, haslo_hash=hashed)
-        db.session.add(admin)
+        admin_user = Uzytkownik(
+            login=admin_login,
+            haslo_hash=hashed,
+            role="admin",
+            approved=True,
+        )
+        db.session.add(admin_user)
         db.session.commit()
         print(f"✔ Użytkownik administratora '{admin_login}' został dodany.")
     else:
+        admin_user.role = "admin"
+        admin_user.approved = True
+        db.session.commit()
         print(f"ℹ Użytkownik '{admin_login}' już istnieje.")
 
     print("✔ Baza danych została zainicjalizowana.")

--- a/model.py
+++ b/model.py
@@ -26,6 +26,7 @@ class Prowadzacy(db.Model):
 
     uczestnicy = db.relationship("Uczestnik", back_populates="prowadzacy", cascade="all, delete-orphan")
     zajecia = db.relationship("Zajecia", back_populates="prowadzacy", cascade="all, delete-orphan")
+    user = db.relationship("Uzytkownik", back_populates="prowadzacy", uselist=False)
 
 class Uczestnik(db.Model):
     __tablename__ = "uczestnik"
@@ -51,6 +52,11 @@ class Uzytkownik(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     login = db.Column(db.String, unique=True, nullable=False)
     haslo_hash = db.Column(db.String, nullable=False)
+    role = db.Column(db.String, nullable=False)
+    approved = db.Column(db.Boolean, default=False)
+    prowadzacy_id = db.Column(db.Integer, db.ForeignKey("prowadzacy.id"))
+
+    prowadzacy = db.relationship("Prowadzacy", back_populates="user")
 
 def init_db(app):
     with app.app_context():

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -1,7 +1,9 @@
 from flask import render_template, request, redirect, url_for, flash
 from flask_login import login_user, logout_user, login_required
-from werkzeug.security import check_password_hash
-from model import Uzytkownik
+from werkzeug.security import check_password_hash, generate_password_hash
+from model import db, Uzytkownik, Prowadzacy, Uczestnik
+from utils import send_plain_email
+import os
 from . import routes_bp
 
 @routes_bp.route("/login", methods=["GET", "POST"])
@@ -21,3 +23,58 @@ def login():
 def logout():
     logout_user()
     return redirect(url_for("routes.index"))
+
+
+@routes_bp.route("/register", methods=["GET", "POST"])
+def register():
+    if request.method == "POST":
+        imie = request.form.get("imie")
+        nazwisko = request.form.get("nazwisko")
+        numer_umowy = request.form.get("numer_umowy")
+        lista_uczestnikow = request.form.get("lista_uczestnikow")
+        login_val = request.form.get("login")
+        haslo = request.form.get("haslo")
+        podpis = request.files.get("podpis")
+
+        if not all([imie, nazwisko, numer_umowy, lista_uczestnikow, login_val, haslo]):
+            flash("Wszystkie pola oprócz podpisu są wymagane", "danger")
+            return redirect(url_for("routes.register"))
+
+        if Uzytkownik.query.filter_by(login=login_val).first():
+            flash("Login jest już zajęty", "danger")
+            return redirect(url_for("routes.register"))
+
+        filename = None
+        if podpis and podpis.filename:
+            ext = podpis.filename.rsplit(".", 1)[-1]
+            filename = f"{nazwisko}_{login_val}.{ext}"
+            path = os.path.join("static", filename)
+            podpis.save(path)
+
+        prow = Prowadzacy(imie=imie, nazwisko=nazwisko, numer_umowy=numer_umowy, podpis_filename=filename)
+        db.session.add(prow)
+        db.session.flush()
+
+        for linia in lista_uczestnikow.splitlines():
+            nazwa = linia.strip()
+            if nazwa:
+                db.session.add(Uczestnik(imie_nazwisko=nazwa, prowadzacy_id=prow.id))
+
+        user = Uzytkownik(login=login_val,
+                          haslo_hash=generate_password_hash(haslo),
+                          role="prowadzacy",
+                          approved=False,
+                          prowadzacy_id=prow.id)
+        db.session.add(user)
+        db.session.commit()
+
+        send_plain_email(
+            "kontakt@vestmedia.pl",
+            "Nowa rejestracja prowadzącego",
+            f"Zarejestrował się {imie} {nazwisko} (login: {login_val})."
+        )
+
+        flash("Rejestracja zakończona. Poczekaj na zatwierdzenie konta.", "success")
+        return redirect(url_for("routes.login"))
+
+    return render_template("register.html")

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <title>Rejestracja – ShareOKO</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <div class="container mt-5 mb-5" style="max-width: 600px;">
+    <h2 class="mb-4 text-center">Rejestracja prowadzącego</h2>
+    <form method="POST" enctype="multipart/form-data">
+      <div class="mb-3">
+        <label for="imie" class="form-label">Imię:</label>
+        <input type="text" class="form-control" id="imie" name="imie" required>
+      </div>
+      <div class="mb-3">
+        <label for="nazwisko" class="form-label">Nazwisko:</label>
+        <input type="text" class="form-control" id="nazwisko" name="nazwisko" required>
+      </div>
+      <div class="mb-3">
+        <label for="numer_umowy" class="form-label">Numer umowy:</label>
+        <input type="text" class="form-control" id="numer_umowy" name="numer_umowy" required>
+      </div>
+      <div class="mb-3">
+        <label for="lista_uczestnikow" class="form-label">Lista uczestników (po jednym na linię):</label>
+        <textarea class="form-control" id="lista_uczestnikow" name="lista_uczestnikow" rows="5" required></textarea>
+      </div>
+      <div class="mb-3">
+        <label for="login" class="form-label">Login:</label>
+        <input type="text" class="form-control" id="login" name="login" required>
+      </div>
+      <div class="mb-3">
+        <label for="haslo" class="form-label">Hasło:</label>
+        <input type="password" class="form-control" id="haslo" name="haslo" required>
+      </div>
+      <div class="mb-3">
+        <label for="podpis" class="form-label">Podpis (.png lub .jpg, opcjonalnie):</label>
+        <input type="file" class="form-control" id="podpis" name="podpis" accept=".png,.jpg,.jpeg">
+      </div>
+      {% with messages = get_flashed_messages(with_categories=True) %}
+        {% if messages %}
+          {% for category, message in messages %}
+            <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+      <div class="d-grid">
+        <button type="submit" class="btn btn-primary">Zarejestruj</button>
+      </div>
+    </form>
+  </div>
+</body>
+</html>

--- a/utils.py
+++ b/utils.py
@@ -89,3 +89,31 @@ def email_do_koordynatora(buf, data, typ="lista"):
         logger.info("Mail sent to %s", odbiorca)
     except Exception as e:
         logger.exception("Failed to send email: %s", e)
+
+
+def send_plain_email(to_addr: str, subject: str, body: str) -> None:
+    """Send a simple text e-mail."""
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg.set_content(body)
+    msg["From"] = f"Vest Media <{os.getenv('EMAIL_LOGIN')}>"
+    msg["To"] = to_addr
+
+    host = os.getenv("SMTP_HOST")
+    port = int(os.getenv("SMTP_PORT"))
+    login = os.getenv("EMAIL_LOGIN")
+    password = os.getenv("EMAIL_PASSWORD")
+
+    try:
+        if port == 465:
+            with smtplib.SMTP_SSL(host, port) as smtp:
+                smtp.login(login, password)
+                smtp.send_message(msg)
+        else:
+            with smtplib.SMTP(host, port) as smtp:
+                smtp.starttls()
+                smtp.login(login, password)
+                smtp.send_message(msg)
+        logger.info("Mail sent to %s", to_addr)
+    except Exception as e:
+        logger.exception("Failed to send email: %s", e)


### PR DESCRIPTION
## Summary
- extend `Uzytkownik` with `role`, `approved` and link to `Prowadzacy`
- add email helper `send_plain_email`
- implement `/register` route and HTML form
- create admin user with role/approval in `init_db`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68444b42b974832a8a1e493df263fa41