### PR TITLE
Implement instructor login flow

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -12,7 +12,10 @@ with app.app_context():
 
     if not Uzytkownik.query.filter_by(login=admin_login).first():
         hashed = generate_password_hash(admin_password)
-        admin = Uzytkownik(login=admin_login, haslo_hash=hashed)
+        admin = Uzytkownik(login=admin_login,
+                           haslo_hash=hashed,
+                           role="admin",
+                           approved=True)
         db.session.add(admin)
         db.session.commit()
         print(f"✔ Użytkownik administratora '{admin_login}' został dodany.")

--- a/model.py
+++ b/model.py
@@ -51,6 +51,8 @@ class Uzytkownik(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     login = db.Column(db.String, unique=True, nullable=False)
     haslo_hash = db.Column(db.String, nullable=False)
+    role = db.Column(db.String, nullable=False, default="prowadzacy")
+    approved = db.Column(db.Boolean, default=False)
 
 def init_db(app):
     with app.app_context():

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -11,8 +11,13 @@ def login():
         haslo = request.form.get("hasło")
         user = Uzytkownik.query.filter_by(login=login_val).first()
         if user and check_password_hash(user.haslo_hash, haslo):
+            if user.role == "prowadzacy" and not user.approved:
+                flash("Konto oczekuje na zatwierdzenie", "warning")
+                return render_template("login.html")
             login_user(user)
-            return redirect(url_for("routes.admin_dashboard"))
+            if user.role == "admin":
+                return redirect(url_for("routes.admin_dashboard"))
+            return redirect(url_for("routes.index"))
         flash("Nieprawidłowe dane logowania", "danger")
     return render_template("login.html")
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -24,7 +24,7 @@
 </head>
 <body>
   <div class="login-box">
-    <h2 class="mb-4 text-center">Logowanie administratora</h2>
+    <h2 class="mb-4 text-center">Logowanie</h2>
     <form method="POST" action="/login">
       <div class="mb-3">
         <label for="login" class="form-label">Login:</label>
@@ -44,6 +44,10 @@
       <div class="d-grid mt-3">
         <button type="submit" class="btn btn-primary">Zaloguj się</button>
       </div>
+      <p class="text-center mt-3">
+        Nie masz konta?
+        <a href="/register">Zarejestruj się</a>
+      </p>
     </form>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- add `role` and `approved` fields to `Uzytkownik`
- seed admin account with role and approval
- refine login logic to handle instructors and admins
- tweak login page wording and link to registration

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68444b55f804832ab3659a914e8b3bfe