### PR TITLE
Restrict index access and handle instructor roles

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -12,7 +12,7 @@ with app.app_context():
 
     if not Uzytkownik.query.filter_by(login=admin_login).first():
         hashed = generate_password_hash(admin_password)
-        admin = Uzytkownik(login=admin_login, haslo_hash=hashed)
+        admin = Uzytkownik(login=admin_login, haslo_hash=hashed, role="admin")
         db.session.add(admin)
         db.session.commit()
         print(f"✔ Użytkownik administratora '{admin_login}' został dodany.")

--- a/model.py
+++ b/model.py
@@ -51,6 +51,8 @@ class Uzytkownik(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     login = db.Column(db.String, unique=True, nullable=False)
     haslo_hash = db.Column(db.String, nullable=False)
+    role = db.Column(db.String, default="user")
+    prowadzacy_id = db.Column(db.Integer, db.ForeignKey("prowadzacy.id"))
 
 def init_db(app):
     with app.app_context():

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -12,7 +12,9 @@ def login():
         user = Uzytkownik.query.filter_by(login=login_val).first()
         if user and check_password_hash(user.haslo_hash, haslo):
             login_user(user)
-            return redirect(url_for("routes.admin_dashboard"))
+            if user.role == "admin":
+                return redirect(url_for("routes.admin_dashboard"))
+            return redirect(url_for("routes.index"))
         flash("Nieprawidłowe dane logowania", "danger")
     return render_template("login.html")
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -40,6 +40,7 @@
 
     <form method="POST" enctype="multipart/form-data" aria-label="Formularz listy obecności">
       <div class="mb-3 d-flex justify-content-between align-items-center">
+        {% if is_admin %}
         <div class="w-100">
           <label for="prowadzący" class="form-label">Wybierz prowadzącego:</label>
           <select name="prowadzący" id="prowadzący" class="form-select" required aria-required="true">
@@ -51,6 +52,10 @@
         <button type="button" class="btn btn-outline-success ms-3" style="white-space: nowrap;" data-bs-toggle="modal" data-bs-target="#dodajModal">
           <i class="bi bi-person-plus"></i>
         </button>
+        {% else %}
+        <input type="hidden" name="prowadzący" value="{{ selected }}">
+        <p class="mb-0 fw-bold">Prowadzący: {{ prowadzacy[0].nazwisko if prowadzacy }}</p>
+        {% endif %}
       </div>
 
       <div class="mb-3">
@@ -84,6 +89,7 @@
 
     </form>
 
+    {% if is_admin %}
     <div class="modal fade" id="dodajModal" tabindex="-1" aria-labelledby="dodajModalLabel" aria-hidden="true">
       <div class="modal-dialog">
         <div class="modal-content">
@@ -118,6 +124,7 @@
         </div>
       </div>
     </div>
+    {% endif %}
   </main>
 
   <footer class="text-center text-white bg-dark py-4">
@@ -155,15 +162,18 @@
       toggleTheme();
     }
 
-    document.getElementById("prowadzący").addEventListener("change", () => {
-      const form = document.querySelector("form");
-      const hidden = document.createElement("input");
-      hidden.type = "hidden";
-      hidden.name = "akcja";
-      hidden.value = "zmien_prowadzacego";
-      form.appendChild(hidden);
-      form.submit();
-    });
+    const prowadzacySelect = document.getElementById("prowadzący");
+    if (prowadzacySelect) {
+      prowadzacySelect.addEventListener("change", () => {
+        const form = document.querySelector("form");
+        const hidden = document.createElement("input");
+        hidden.type = "hidden";
+        hidden.name = "akcja";
+        hidden.value = "zmien_prowadzacego";
+        form.appendChild(hidden);
+        form.submit();
+      });
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `role` and `prowadzacy_id` to `Uzytkownik`
- seed admin user with role in `init_db`
- redirect after login depending on user role
- protect the index route and filter participants based on role
- update index template to show instructor list only to admins

## Testing
- `python -m py_compile init_db.py model.py routes/attendance.py routes/auth.py`

------
https://chatgpt.com/codex/tasks/task_e_68444b627898832aa57558da76b51150