### PR TITLE
Add instructor panel with edit and session management

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -12,7 +12,7 @@ with app.app_context():
 
     if not Uzytkownik.query.filter_by(login=admin_login).first():
         hashed = generate_password_hash(admin_password)
-        admin = Uzytkownik(login=admin_login, haslo_hash=hashed)
+        admin = Uzytkownik(login=admin_login, haslo_hash=hashed, rola="admin")
         db.session.add(admin)
         db.session.commit()
         print(f"✔ Użytkownik administratora '{admin_login}' został dodany.")

--- a/model.py
+++ b/model.py
@@ -51,6 +51,10 @@ class Uzytkownik(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     login = db.Column(db.String, unique=True, nullable=False)
     haslo_hash = db.Column(db.String, nullable=False)
+    rola = db.Column(db.String, default="prowadzacy")
+    prowadzacy_id = db.Column(db.Integer, db.ForeignKey("prowadzacy.id"))
+
+    prowadzacy = db.relationship("Prowadzacy")
 
 def init_db(app):
     with app.app_context():

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -2,4 +2,4 @@ from flask import Blueprint
 
 routes_bp = Blueprint("routes", __name__)
 
-from . import auth, attendance, admin  # noqa: E402,F401
+from . import auth, attendance, admin, panel  # noqa: E402,F401

--- a/routes/panel.py
+++ b/routes/panel.py
@@ -1,0 +1,125 @@
+from flask import render_template, redirect, url_for, request, flash, send_file
+from flask_login import login_required, current_user
+from datetime import datetime
+from io import BytesIO
+import os
+
+from model import db, Prowadzacy, Zajecia, Uczestnik
+from doc_generator import generuj_liste_obecnosci
+from . import routes_bp
+
+
+def _check_role():
+    if not current_user.is_authenticated or current_user.rola != "prowadzacy":
+        return False
+    return True
+
+
+@routes_bp.route("/panel")
+@login_required
+def panel():
+    if not _check_role():
+        return "Brak dostępu", 403
+
+    prow = Prowadzacy.query.get(current_user.prowadzacy_id)
+    if not prow:
+        return "Nie znaleziono prowadzącego", 404
+
+    uczestnicy = sorted(prow.uczestnicy, key=lambda u: u.imie_nazwisko.lower())
+    zajecia = Zajecia.query.filter_by(prowadzacy_id=prow.id).order_by(Zajecia.data.desc()).all()
+
+    return render_template(
+        "panel.html",
+        prowadzacy=prow,
+        uczestnicy=uczestnicy,
+        zajecia=zajecia,
+    )
+
+
+@routes_bp.route("/panel/edytuj_dane", methods=["POST"])
+@login_required
+def edytuj_dane():
+    if not _check_role():
+        return "Brak dostępu", 403
+
+    prow = Prowadzacy.query.get(current_user.prowadzacy_id)
+    if not prow:
+        return "Nie znaleziono", 404
+
+    prow.nazwisko = request.form.get("nazwisko")
+    prow.numer_umowy = request.form.get("numer_umowy")
+    db.session.commit()
+    flash("Dane zostały zaktualizowane", "success")
+    return redirect(url_for("routes.panel"))
+
+
+@routes_bp.route("/panel/edytuj_uczestnikow", methods=["POST"])
+@login_required
+def edytuj_uczestnikow():
+    if not _check_role():
+        return "Brak dostępu", 403
+
+    prow = Prowadzacy.query.get(current_user.prowadzacy_id)
+    if not prow:
+        return "Nie znaleziono", 404
+
+    prow.uczestnicy.clear()
+    lista = request.form.get("uczestnicy", "").strip().splitlines()
+    for nazwisko in lista:
+        if nazwisko.strip():
+            prow.uczestnicy.append(Uczestnik(imie_nazwisko=nazwisko.strip()))
+    db.session.commit()
+    flash("Zaktualizowano listę uczestników", "success")
+    return redirect(url_for("routes.panel"))
+
+
+@routes_bp.route("/panel/usun_zajecie/<int:zaj_id>", methods=["POST"])
+@login_required
+def panel_usun_zajecie(zaj_id):
+    if not _check_role():
+        return "Brak dostępu", 403
+
+    zaj = Zajecia.query.get(zaj_id)
+    if not zaj or zaj.prowadzacy_id != current_user.prowadzacy_id:
+        return "Brak dostępu", 404
+
+    db.session.delete(zaj)
+    db.session.commit()
+    flash("Zajęcia usunięte", "info")
+    return redirect(url_for("routes.panel"))
+
+
+@routes_bp.route("/panel/pobierz_zajecie/<int:zaj_id>")
+@login_required
+def panel_pobierz_zajecie(zaj_id):
+    if not _check_role():
+        return "Brak dostępu", 403
+
+    zaj = Zajecia.query.get(zaj_id)
+    if not zaj or zaj.prowadzacy_id != current_user.prowadzacy_id:
+        return "Brak dostępu", 404
+
+    obecni = [u.imie_nazwisko for u in zaj.obecni]
+    podpis_path = None
+    if zaj.prowadzacy.podpis_filename:
+        podpis_path = os.path.join("static", zaj.prowadzacy.podpis_filename)
+
+    doc = generuj_liste_obecnosci(
+        zaj.data.strftime("%Y-%m-%d"),
+        zaj.czas_trwania,
+        obecni,
+        zaj.prowadzacy.nazwisko,
+        podpis_path,
+    )
+
+    buf = BytesIO()
+    doc.save(buf)
+    buf.seek(0)
+
+    return send_file(
+        buf,
+        mimetype="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        as_attachment=True,
+        download_name=f"lista_{zaj.id}.docx",
+    )
+

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <title>Panel prowadzącego – ShareOKO</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container-fluid">
+      <span class="navbar-brand">Panel prowadzącego</span>
+      <div class="d-flex">
+        <a href="{{ url_for('routes.logout') }}" class="btn btn-outline-light">Wyloguj</a>
+      </div>
+    </div>
+  </nav>
+
+  <main class="container mt-4 mb-5">
+    {% with messages = get_flashed_messages(with_categories=True) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="alert alert-{{ category }} mt-3" role="alert">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+
+    <h2>Dane osobowe</h2>
+    <form method="POST" action="{{ url_for('routes.edytuj_dane') }}" class="row g-3 mb-4">
+      <div class="col-md-6">
+        <label class="form-label">Nazwisko</label>
+        <input type="text" name="nazwisko" value="{{ prowadzacy.nazwisko }}" class="form-control" required>
+      </div>
+      <div class="col-md-6">
+        <label class="form-label">Numer umowy</label>
+        <input type="text" name="numer_umowy" value="{{ prowadzacy.numer_umowy }}" class="form-control" required>
+      </div>
+      <div class="col-md-6">
+        <label class="form-label">Podpis</label>
+        <input type="text" value="{{ 'tak' if prowadzacy.podpis_filename else 'nie' }}" class="form-control" disabled>
+      </div>
+      <div class="col-12">
+        <button type="submit" class="btn btn-primary">Zapisz dane</button>
+      </div>
+    </form>
+
+    <h2>Uczestnicy</h2>
+    <form method="POST" action="{{ url_for('routes.edytuj_uczestnikow') }}" class="mb-5">
+      <textarea name="uczestnicy" class="form-control" rows="5">{% for u in uczestnicy %}{{ u.imie_nazwisko }}{% if not loop.last %}\n{% endif %}{% endfor %}</textarea>
+      <button type="submit" class="btn btn-primary mt-2">Zapisz uczestników</button>
+    </form>
+
+    <h2>Zajęcia</h2>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>Data</th>
+          <th>Czas trwania</th>
+          <th>Obecni</th>
+          <th>Akcje</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for z in zajecia %}
+        <tr>
+          <td>{{ z.data }}</td>
+          <td>{{ z.czas_trwania }}</td>
+          <td>
+            <ul class="mb-0">
+              {% for o in z.obecni %}
+                <li>{{ o.imie_nazwisko }}</li>
+              {% endfor %}
+            </ul>
+          </td>
+          <td class="text-nowrap">
+            <a href="{{ url_for('routes.panel_pobierz_zajecie', zaj_id=z.id) }}" class="btn btn-sm text-primary" title="Pobierz"><i class="bi bi-download"></i></a>
+            <form action="{{ url_for('routes.panel_usun_zajecie', zaj_id=z.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Usunąć zajęcia?')">
+              <button type="submit" class="btn btn-sm text-danger"><i class="bi bi-trash"></i></button>
+            </form>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend user model with role and prowadzacy relation
- setup admin role in init_db
- register new `panel` routes blueprint
- implement instructor panel endpoints
- add bootstrap based panel template

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68444b70ae4c832abc3c3760c2b6e577