### PR TITLE
Sanitize signature file uploads

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -4,6 +4,7 @@ from model import db, Prowadzacy, Zajecia, Uczestnik, Uzytkownik
 from utils import email_do_koordynatora, send_plain_email
 from doc_generator import generuj_raport_miesieczny
 from io import BytesIO
+from werkzeug.utils import secure_filename
 import os
 from . import routes_bp
 
@@ -113,8 +114,9 @@ def dodaj_prowadzacego():
         db.session.add(prow)
         db.session.flush()
 
-    if podpis:
-        filename = f"{trener}.{podpis.filename.split('.')[-1]}"
+    if podpis and podpis.filename:
+        sanitized = secure_filename(podpis.filename)
+        filename = f"{prow.id}_{sanitized}"
         path = os.path.join('static', filename)
         podpis.save(path)
         prow.podpis_filename = filename

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -1,9 +1,11 @@
 from flask import render_template, request, redirect, url_for, flash
 from flask_login import login_user, logout_user, login_required
 from werkzeug.security import check_password_hash, generate_password_hash
+from werkzeug.utils import secure_filename
 from model import db, Uzytkownik, Prowadzacy, Uczestnik
 from utils import send_plain_email
 import os
+import uuid
 from . import routes_bp
 
 @routes_bp.route("/login", methods=["GET", "POST"])
@@ -56,8 +58,8 @@ def register():
 
         filename = None
         if podpis and podpis.filename:
-            ext = podpis.filename.rsplit(".", 1)[-1]
-            filename = f"{nazwisko}_{login_val}.{ext}"
+            sanitized = secure_filename(podpis.filename)
+            filename = f"{uuid.uuid4().hex}_{sanitized}"
             path = os.path.join("static", filename)
             podpis.save(path)
 


### PR DESCRIPTION
## Summary
- ensure upload filenames are sanitized
- create placeholder static directory to hold signatures

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684450706bfc832a9831d9ba35e3d7c7