### PR TITLE
Add instructor panel view

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -2,4 +2,4 @@ from flask import Blueprint
 
 routes_bp = Blueprint("routes", __name__)
 
-from . import auth, attendance, admin  # noqa: E402,F401
+from . import auth, attendance, admin, panel  # noqa: E402,F401

--- a/routes/panel.py
+++ b/routes/panel.py
@@ -1,0 +1,112 @@
+from flask import render_template, redirect, url_for, flash, send_file, request
+from flask_login import login_required, current_user
+from werkzeug.utils import secure_filename
+from io import BytesIO
+from model import db, Prowadzacy, Uczestnik, Zajecia
+from doc_generator import generuj_liste_obecnosci
+from . import routes_bp
+import os
+
+
+@routes_bp.route('/panel')
+@login_required
+def panel():
+    if current_user.role != 'prowadzacy':
+        return 'Brak dost\u0119pu', 403
+
+    prow = current_user.prowadzacy
+    if not prow:
+        return 'Brak danych prowad\u0105cego', 404
+
+    uczestnicy = sorted(prow.uczestnicy, key=lambda x: x.imie_nazwisko.lower())
+    zajecia = Zajecia.query.filter_by(prowadzacy_id=prow.id).order_by(Zajecia.data.desc()).all()
+    return render_template('panel.html', prowadzacy=prow, uczestnicy=uczestnicy, zajecia=zajecia)
+
+
+@routes_bp.route('/panel/profil', methods=['POST'])
+@login_required
+def panel_update_profile():
+    if current_user.role != 'prowadzacy':
+        return 'Brak dost\u0119pu', 403
+
+    prow = current_user.prowadzacy
+    if not prow:
+        return 'Brak danych', 404
+
+    prow.imie = request.form.get('imie')
+    prow.nazwisko = request.form.get('nazwisko')
+    prow.numer_umowy = request.form.get('numer_umowy')
+
+    podpis = request.files.get('podpis')
+    if podpis and podpis.filename:
+        sanitized = secure_filename(podpis.filename)
+        filename = f"{prow.id}_{sanitized}"
+        path = os.path.join('static', filename)
+        podpis.save(path)
+        prow.podpis_filename = filename
+
+    db.session.commit()
+    flash('Dane zaktualizowane', 'success')
+    return redirect(url_for('routes.panel'))
+
+
+@routes_bp.route('/panel/uczestnicy', methods=['POST'])
+@login_required
+def panel_update_participants():
+    if current_user.role != 'prowadzacy':
+        return 'Brak dost\u0119pu', 403
+
+    prow = current_user.prowadzacy
+    if not prow:
+        return 'Brak danych', 404
+
+    lista = request.form.get('uczestnicy')
+    prow.uczestnicy.clear()
+    if lista:
+        for linia in lista.strip().splitlines():
+            nazwa = linia.strip()
+            if nazwa:
+                prow.uczestnicy.append(Uczestnik(imie_nazwisko=nazwa))
+    db.session.commit()
+    flash('Lista uczestnik\u00f3w zaktualizowana', 'success')
+    return redirect(url_for('routes.panel'))
+
+
+@routes_bp.route('/pobierz_zajecie/<int:id>')
+@login_required
+def pobierz_zajecie(id):
+    zaj = Zajecia.query.get(id)
+    if not zaj or zaj.prowadzacy_id != current_user.prowadzacy_id:
+        return 'Brak dost\u0119pu', 403
+
+    prow = current_user.prowadzacy
+    obecni = [u.imie_nazwisko for u in zaj.obecni]
+    doc = generuj_liste_obecnosci(
+        zaj.data.strftime('%Y-%m-%d'),
+        str(zaj.czas_trwania).replace('.', ','),
+        obecni,
+        prow.nazwisko,
+        os.path.join('static', prow.podpis_filename)
+    )
+
+    buf = BytesIO()
+    doc.save(buf)
+    buf.seek(0)
+    data_str = zaj.data.strftime('%Y-%m-%d')
+    return send_file(buf,
+                     mimetype='application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                     as_attachment=True,
+                     download_name=f'lista_{data_str}.docx')
+
+
+@routes_bp.route('/usun_moje_zajecie/<int:id>', methods=['POST'])
+@login_required
+def usun_moje_zajecie(id):
+    zaj = Zajecia.query.get(id)
+    if not zaj or zaj.prowadzacy_id != current_user.prowadzacy_id:
+        return 'Brak dost\u0119pu', 403
+
+    db.session.delete(zaj)
+    db.session.commit()
+    flash('Zaj\u0119cia usuni\u0119te', 'info')
+    return redirect(url_for('routes.panel'))

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <title>Panel prowadzącego – ShareOKO</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container-fluid">
+      <span class="navbar-brand">Panel prowadzącego</span>
+      <div class="d-flex">
+        <a href="{{ url_for('routes.logout') }}" class="btn btn-outline-light">Wyloguj</a>
+      </div>
+    </div>
+  </nav>
+
+  <main class="container mt-5 mb-5">
+    {% with messages = get_flashed_messages(with_categories=True) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+
+    <h2 class="mb-4">Moje dane</h2>
+    <form method="POST" action="{{ url_for('routes.panel_update_profile') }}" enctype="multipart/form-data" class="mb-5">
+      <div class="row g-3">
+        <div class="col-md-4">
+          <label for="imie" class="form-label">Imię:</label>
+          <input type="text" class="form-control" id="imie" name="imie" value="{{ prowadzacy.imie }}">
+        </div>
+        <div class="col-md-4">
+          <label for="nazwisko" class="form-label">Nazwisko:</label>
+          <input type="text" class="form-control" id="nazwisko" name="nazwisko" value="{{ prowadzacy.nazwisko }}">
+        </div>
+        <div class="col-md-4">
+          <label for="numer_umowy" class="form-label">Numer umowy:</label>
+          <input type="text" class="form-control" id="numer_umowy" name="numer_umowy" value="{{ prowadzacy.numer_umowy }}">
+        </div>
+        <div class="col-md-6">
+          <label for="podpis" class="form-label">Podpis (.png/.jpg):</label>
+          <input type="file" class="form-control" id="podpis" name="podpis" accept=".png,.jpg,.jpeg">
+        </div>
+      </div>
+      <div class="mt-3">
+        <button type="submit" class="btn btn-primary">Zapisz dane</button>
+      </div>
+    </form>
+
+    <h2 class="mb-4">Uczestnicy</h2>
+    <form method="POST" action="{{ url_for('routes.panel_update_participants') }}" class="mb-5">
+      <div class="mb-3">
+        <textarea class="form-control" name="uczestnicy" rows="5">{% for u in uczestnicy %}{{ u.imie_nazwisko }}{% if not loop.last %}
+{% endif %}{% endfor %}</textarea>
+      </div>
+      <button type="submit" class="btn btn-primary">Zapisz listę</button>
+    </form>
+
+    <h2 class="mb-4">Historia zajęć</h2>
+    <table class="table table-striped table-hover">
+      <thead class="table-secondary">
+        <tr>
+          <th>Data</th>
+          <th>Czas</th>
+          <th>Obecni</th>
+          <th>Akcja</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for z in zajecia %}
+        <tr>
+          <td>{{ z.data.date() }}</td>
+          <td>{{ z.czas_trwania }}</td>
+          <td>
+            <ul class="mb-0">
+              {% for o in z.obecni %}
+                <li>{{ o.imie_nazwisko }}</li>
+              {% endfor %}
+            </ul>
+          </td>
+          <td class="text-nowrap">
+            <a href="{{ url_for('routes.pobierz_zajecie', id=z.id) }}" class="btn btn-sm text-primary"><i class="bi bi-download"></i></a>
+            <form action="{{ url_for('routes.usun_moje_zajecie', id=z.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Usunąć zajęcia?')">
+              <button type="submit" class="btn btn-sm text-danger"><i class="bi bi-trash"></i></button>
+            </form>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- new panel blueprint to let instructors manage their data
- routes for updating profile/participants and handling sessions
- instructor panel page template

## Testing
- `python -m py_compile app.py routes/*.py model.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6844512697b8832aa710e498c5a72be4