### PR TITLE
Limit index view by role

### DIFF
--- a/routes/attendance.py
+++ b/routes/attendance.py
@@ -1,35 +1,48 @@
 from flask import render_template, request, redirect, url_for, flash, send_file
-from flask_login import current_user
+from flask_login import current_user, login_required
 from model import Prowadzacy
+
 from utils import przetworz_liste_obecnosci, email_do_koordynatora
 from . import routes_bp
-import os
+
 
 @routes_bp.route('/', methods=['GET', 'POST'])
+@login_required
 def index():
-    prowadzacy = Prowadzacy.query.all()
     status = None
     akcja = None
 
-    try:
-        selected_id = int(request.form.get('prowadzący'))
-    except (TypeError, ValueError):
-        selected_id = prowadzacy[0].id if prowadzacy else None
+    if current_user.role == 'admin':
+        prowadzacy = Prowadzacy.query.all()
+        try:
+            selected_id = int(request.form.get('prowadzący'))
+        except (TypeError, ValueError):
+            selected_id = prowadzacy[0].id if prowadzacy else None
+        wybrany = Prowadzacy.query.get(selected_id)
+    else:
+        wybrany = current_user.prowadzacy
+        prowadzacy = [wybrany] if wybrany else []
+        selected_id = current_user.prowadzacy_id
 
-    wybrany = Prowadzacy.query.get(selected_id)
-    uczestnicy = sorted(wybrany.uczestnicy, key=lambda x: x.imie_nazwisko.lower()) if wybrany else []
+    uczestnicy = (
+        sorted(wybrany.uczestnicy, key=lambda x: x.imie_nazwisko.lower())
+        if wybrany
+        else []
+    )
 
     if request.method == 'POST':
         akcja = request.form.get('akcja')
 
-        if akcja == 'zmien_prowadzacego':
-            return render_template('index.html',
-                                   prowadzacy=prowadzacy,
-                                   uczestnicy=uczestnicy,
-                                   selected=selected_id,
-                                   status=status,
-                                   is_admin=current_user.is_authenticated and current_user.login == os.getenv('ADMIN_LOGIN'),
-                                   is_logged=current_user.is_authenticated)
+        if current_user.role == 'admin' and akcja == 'zmien_prowadzacego':
+            return render_template(
+                'index.html',
+                prowadzacy=prowadzacy,
+                uczestnicy=uczestnicy,
+                selected=selected_id,
+                status=status,
+                is_admin=True,
+                is_logged=True,
+            )
         elif akcja in ['pobierz', 'wyslij']:
             result = przetworz_liste_obecnosci(request.form, wybrany)
             if isinstance(result, tuple) and result[0] == 'error':
@@ -38,10 +51,15 @@ def index():
             elif isinstance(result, tuple):
                 status, buf, data_str = result
                 if akcja == 'pobierz':
-                    return send_file(buf,
-                                     mimetype='application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-                                     as_attachment=True,
-                                     download_name=f'lista_{data_str}.docx')
+                    return send_file(
+                        buf,
+                        mimetype=(
+                            'application/vnd.openxmlformats-officedocument.'
+                            'wordprocessingml.document'
+                        ),
+                        as_attachment=True,
+                        download_name=f'lista_{data_str}.docx',
+                    )
                 elif akcja == 'wyslij':
                     email_do_koordynatora(buf, data_str, typ='lista')
                     flash('Lista została wysłana e-mailem', 'success')
@@ -52,5 +70,5 @@ def index():
                            uczestnicy=uczestnicy,
                            selected=selected_id,
                            status=status,
-                           is_admin=current_user.is_authenticated and current_user.login == os.getenv('ADMIN_LOGIN'),
-                           is_logged=current_user.is_authenticated)
+                           is_admin=current_user.role == 'admin',
+                           is_logged=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -39,6 +39,7 @@
     {% endwith %}
 
     <form method="POST" enctype="multipart/form-data" aria-label="Formularz listy obecności">
+      {% if is_admin %}
       <div class="mb-3 d-flex justify-content-between align-items-center">
         <div class="w-100">
           <label for="prowadzący" class="form-label">Wybierz prowadzącego:</label>
@@ -52,6 +53,9 @@
           <i class="bi bi-person-plus"></i>
         </button>
       </div>
+      {% else %}
+      <input type="hidden" name="prowadzący" value="{{ selected }}">
+      {% endif %}
 
       <div class="mb-3">
         <label for="data" class="form-label">Data zajęć:</label>
@@ -84,6 +88,7 @@
 
     </form>
 
+    {% if is_admin %}
     <div class="modal fade" id="dodajModal" tabindex="-1" aria-labelledby="dodajModalLabel" aria-hidden="true">
       <div class="modal-dialog">
         <div class="modal-content">
@@ -118,6 +123,7 @@
         </div>
       </div>
     </div>
+    {% endif %}
   </main>
 
   <footer class="text-center text-white bg-dark py-4">
@@ -155,6 +161,7 @@
       toggleTheme();
     }
 
+    {% if is_admin %}
     document.getElementById("prowadzący").addEventListener("change", () => {
       const form = document.querySelector("form");
       const hidden = document.createElement("input");
@@ -164,6 +171,7 @@
       form.appendChild(hidden);
       form.submit();
     });
+    {% endif %}
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- require login to access the index route
- show trainer dropdown and modal only for admins
- limit non-admin users to their own participant list

## Testing
- `python -m py_compile routes/attendance.py`
- `flake8 routes/attendance.py`

------
https://chatgpt.com/codex/tasks/task_e_68445217e0fc832ab6a4874d9b88ebbe