### PR TITLE
Refactor admin role checks

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -11,7 +11,7 @@ from . import routes_bp
 @routes_bp.route('/admin')
 @login_required
 def admin_dashboard():
-    if current_user.login != os.getenv('ADMIN_LOGIN'):
+    if current_user.role != 'admin':
         return 'Brak dostępu', 403
 
     prowadzacy = Prowadzacy.query.all()
@@ -38,7 +38,7 @@ def admin_dashboard():
 @routes_bp.route('/usun_zajecie/<int:id>', methods=['POST'])
 @login_required
 def usun_zajecie(id):
-    if current_user.login != os.getenv('ADMIN_LOGIN'):
+    if current_user.role != 'admin':
         return 'Brak dostępu', 403
 
     zaj = Zajecia.query.get(id)
@@ -53,7 +53,7 @@ def usun_zajecie(id):
 @routes_bp.route('/raport/<int:prowadzacy_id>', methods=['GET'])
 @login_required
 def raport(prowadzacy_id):
-    if current_user.login != os.getenv('ADMIN_LOGIN'):
+    if current_user.role != 'admin':
         return 'Brak dostępu', 403
 
     prow = Prowadzacy.query.get(prowadzacy_id)
@@ -88,7 +88,7 @@ def raport(prowadzacy_id):
 @routes_bp.route('/dodaj', methods=['POST'])
 @login_required
 def dodaj_prowadzacego():
-    if current_user.login != os.getenv('ADMIN_LOGIN'):
+    if current_user.role != 'admin':
         return 'Brak dostępu', 403
 
     id_edit = request.form.get('edit_id')
@@ -132,7 +132,7 @@ def dodaj_prowadzacego():
 @routes_bp.route('/usun/<id>', methods=['POST'])
 @login_required
 def usun_prowadzacego(id):
-    if current_user.login != os.getenv('ADMIN_LOGIN'):
+    if current_user.role != 'admin':
         return 'Brak dostępu', 403
 
     prow = Prowadzacy.query.get(id)
@@ -150,7 +150,7 @@ def usun_prowadzacego(id):
 @routes_bp.route('/approve_user/<int:id>', methods=['POST'])
 @login_required
 def approve_user(id):
-    if current_user.login != os.getenv('ADMIN_LOGIN'):
+    if current_user.role != 'admin':
         return 'Brak dostępu', 403
 
     user = Uzytkownik.query.get(id)

--- a/routes/attendance.py
+++ b/routes/attendance.py
@@ -11,8 +11,9 @@ from . import routes_bp
 def index():
     status = None
     akcja = None
+    is_admin = current_user.role == 'admin'
 
-    if current_user.role == 'admin':
+    if is_admin:
         prowadzacy = Prowadzacy.query.all()
         try:
             selected_id = int(request.form.get('prowadzący'))
@@ -33,14 +34,14 @@ def index():
     if request.method == 'POST':
         akcja = request.form.get('akcja')
 
-        if current_user.role == 'admin' and akcja == 'zmien_prowadzacego':
+        if is_admin and akcja == 'zmien_prowadzacego':
             return render_template(
                 'index.html',
                 prowadzacy=prowadzacy,
                 uczestnicy=uczestnicy,
                 selected=selected_id,
                 status=status,
-                is_admin=True,
+                is_admin=is_admin,
                 is_logged=True,
             )
         elif akcja in ['pobierz', 'wyslij']:
@@ -70,5 +71,5 @@ def index():
                            uczestnicy=uczestnicy,
                            selected=selected_id,
                            status=status,
-                           is_admin=current_user.role == 'admin',
+                           is_admin=is_admin,
                            is_logged=True)

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -22,7 +22,7 @@ def login():
 
             login_user(user)
 
-            if user.role == "admin" or user.login == os.getenv("ADMIN_LOGIN"):
+            if user.role == "admin":
                 return redirect(url_for("routes.admin_dashboard"))
             else:
                 return redirect(url_for("routes.index"))


### PR DESCRIPTION
## Summary
- use `current_user.role` for access control in admin routes
- treat admin user like any other on login
- compute `is_admin` once in `attendance.index`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844531c9ff8832ab038d2ab86eabe64