### PR TITLE
Use logger instead of print

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -1,7 +1,10 @@
 from app import create_app
 from model import db, Uzytkownik
 from werkzeug.security import generate_password_hash
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 app = create_app()
 with app.app_context():
@@ -21,11 +24,11 @@ with app.app_context():
         )
         db.session.add(admin_user)
         db.session.commit()
-        print(f"✔ Użytkownik administratora '{admin_login}' został dodany.")
+        logger.debug("✔ Użytkownik administratora '%s' został dodany.", admin_login)
     else:
         admin_user.role = "admin"
         admin_user.approved = True
         db.session.commit()
-        print(f"ℹ Użytkownik '{admin_login}' już istnieje.")
+        logger.debug("ℹ Użytkownik '%s' już istnieje.", admin_login)
 
-    print("✔ Baza danych została zainicjalizowana.")
+    logger.debug("✔ Baza danych została zainicjalizowana.")


### PR DESCRIPTION
## Summary
- import logging and set up module loggers
- replace print calls in `init_db` and `doc_generator` with logger.debug/warning

## Testing
- `python -m py_compile doc_generator.py init_db.py utils.py routes/panel.py routes/admin.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_684453f58610832a99b07c7d923cefb6