### PR TITLE
Add missing auth page links

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -45,6 +45,9 @@
         <button type="submit" class="btn btn-primary">Zaloguj się</button>
       </div>
     </form>
+    <div class="text-center mt-3">
+      <a href="{{ url_for('routes.register') }}">Zarejestruj się</a>
+    </div>
   </div>
 </body>
 </html>

--- a/templates/register.html
+++ b/templates/register.html
@@ -48,6 +48,9 @@
         <button type="submit" class="btn btn-primary">Zarejestruj</button>
       </div>
     </form>
+    <div class="text-center mt-3">
+      <a href="{{ url_for('routes.login') }}">Powrót do logowania</a>
+    </div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- link to register below login form
- link back to login at the bottom of registration page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68446441b46c832aac142fe1f8bd895c