### PR TITLE
Add CSRF protection with Flask-WTF

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_login import LoginManager
+from flask_wtf import CSRFProtect
 from dotenv import load_dotenv
 import logging
 import os
@@ -12,6 +13,7 @@ load_dotenv()
 migrate = Migrate()
 login_manager = LoginManager()
 login_manager.login_view = "routes.login"  # Redirect to login page when unauthorized
+csrf = CSRFProtect()
 
 def create_app():
     logging.basicConfig(level=logging.INFO)
@@ -26,6 +28,7 @@ def create_app():
     db.init_app(app)
     migrate.init_app(app, db)
     login_manager.init_app(app)
+    csrf.init_app(app)
 
     # Rejestracja blueprintów
     from routes import routes_bp

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flask_migrate
 flask_login
 python-dotenv
 python-docx
+Flask-WTF

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -38,6 +38,7 @@
           <td>{{ u.prowadzacy.imie }} {{ u.prowadzacy.nazwisko }}</td>
           <td>
             <form action="{{ url_for('routes.approve_user', id=u.id) }}" method="POST" class="d-inline">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <button type="submit" class="btn btn-sm btn-success">Akceptuj</button>
             </form>
           </td>
@@ -92,6 +93,7 @@
               <i class="bi bi-pencil"></i>
             </button>
             <form action="{{ url_for('routes.usun_prowadzacego', id=p.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć?')">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <button type="submit" class="btn btn-sm text-danger"><i class="bi bi-trash"></i></button>
             </form>
             <button class="btn btn-sm text-primary" data-bs-toggle="modal" data-bs-target="#raportModal{{ p.id }}">
@@ -104,6 +106,7 @@
           <div class="modal-dialog">
             <div class="modal-content">
               <form method="GET" action="{{ url_for('routes.raport', prowadzacy_id=p.id) }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <div class="modal-header">
                   <h5 class="modal-title" id="raportModalLabel{{ p.id }}">Raport miesięczny</h5>
                   <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>
@@ -159,6 +162,7 @@
           </td>
           <td>
             <form action="{{ url_for('routes.usun_zajecie', id=z.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć zajęcia?')">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <button type="submit" class="btn btn-sm text-danger"><i class="bi bi-trash"></i></button>
             </form>
           </td>
@@ -172,6 +176,7 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <form method="POST" action="/dodaj" enctype="multipart/form-data">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <div class="modal-header">
             <h5 class="modal-title" id="dodajModalLabel">Dodaj / Edytuj prowadzącego</h5>
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -39,6 +39,7 @@
     {% endwith %}
 
     <form method="POST" enctype="multipart/form-data" aria-label="Formularz listy obecności">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       {% if is_admin %}
       <div class="mb-3 d-flex justify-content-between align-items-center">
         <div class="w-100">
@@ -93,6 +94,7 @@
       <div class="modal-dialog">
         <div class="modal-content">
           <form method="POST" action="/dodaj" enctype="multipart/form-data">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <div class="modal-header">
               <h5 class="modal-title" id="dodajModalLabel">Dodaj / Edytuj prowadzącego</h5>
               <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>

--- a/templates/login.html
+++ b/templates/login.html
@@ -26,6 +26,7 @@
   <div class="login-box">
     <h2 class="mb-4 text-center">Logowanie</h2>
     <form method="POST" action="/login">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="mb-3">
         <label for="login" class="form-label">Login:</label>
         <input type="text" class="form-control" id="login" name="login" required>

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -27,6 +27,7 @@
 
     <h2 class="mb-4">Moje dane</h2>
     <form method="POST" action="{{ url_for('routes.panel_update_profile') }}" enctype="multipart/form-data" class="mb-5">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="row g-3">
         <div class="col-md-4">
           <label for="imie" class="form-label">Imię:</label>
@@ -52,6 +53,7 @@
 
     <h2 class="mb-4">Uczestnicy</h2>
     <form method="POST" action="{{ url_for('routes.panel_update_participants') }}" class="mb-5">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="mb-3">
         <textarea class="form-control" name="uczestnicy" rows="5">{% for u in uczestnicy %}{{ u.imie_nazwisko }}{% if not loop.last %}
 {% endif %}{% endfor %}</textarea>
@@ -84,6 +86,7 @@
           <td class="text-nowrap">
             <a href="{{ url_for('routes.pobierz_zajecie', id=z.id) }}" class="btn btn-sm text-primary"><i class="bi bi-download"></i></a>
             <form action="{{ url_for('routes.usun_moje_zajecie', id=z.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Usunąć zajęcia?')">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <button type="submit" class="btn btn-sm text-danger"><i class="bi bi-trash"></i></button>
             </form>
           </td>

--- a/templates/register.html
+++ b/templates/register.html
@@ -9,6 +9,7 @@
   <div class="container mt-5 mb-5" style="max-width: 600px;">
     <h2 class="mb-4 text-center">Rejestracja prowadzącego</h2>
     <form method="POST" enctype="multipart/form-data">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="mb-3">
         <label for="imie" class="form-label">Imię:</label>
         <input type="text" class="form-control" id="imie" name="imie" required>


### PR DESCRIPTION
## Summary
- install **Flask-WTF**
- initialize `CSRFProtect` in the application
- embed CSRF tokens in all HTML forms

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6844654fa618832a803d5ec04dfa529f