### PR TITLE
Use prowadzacy default time

### DIFF
--- a/routes/attendance.py
+++ b/routes/attendance.py
@@ -31,6 +31,12 @@ def index():
         else []
     )
 
+    domyslny_czas = (
+        str(wybrany.domyslny_czas).replace('.', ',')
+        if wybrany and wybrany.domyslny_czas
+        else "1,5"
+    )
+
     if request.method == 'POST':
         akcja = request.form.get('akcja')
 
@@ -42,6 +48,7 @@ def index():
                 selected=selected_id,
                 status=status,
                 is_admin=is_admin,
+                domyslny_czas=domyslny_czas,
                 is_logged=True,
             )
         elif akcja in ['pobierz', 'wyslij']:
@@ -72,4 +79,5 @@ def index():
                            selected=selected_id,
                            status=status,
                            is_admin=is_admin,
+                           domyslny_czas=domyslny_czas,
                            is_logged=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -65,7 +65,7 @@
 
       <div class="mb-3">
         <label for="czas" class="form-label">Czas trwania zajęć:</label>
-        <input type="text" name="czas" id="czas" class="form-control" value="1,5" required>
+        <input type="text" name="czas" id="czas" class="form-control" value="{{ domyslny_czas }}" required>
       </div>
 
       <fieldset class="mb-3" aria-labelledby="uczestnicy-label">


### PR DESCRIPTION
## Summary
- prefill "czas" field from prowadzacy profile if available
- pass time to template and show it dynamically

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446683ab48832aaf16183f0d687595