### PR TITLE
Implement custom error pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, render_template
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_login import LoginManager
@@ -33,6 +33,14 @@ def create_app():
     # Rejestracja blueprintów
     from routes import routes_bp
     app.register_blueprint(routes_bp)
+
+    @app.errorhandler(403)
+    def forbidden(_):
+        return render_template('403.html'), 403
+
+    @app.errorhandler(404)
+    def not_found(_):
+        return render_template('404.html'), 404
 
     return app
 

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -1,4 +1,4 @@
-from flask import render_template, request, redirect, url_for, flash, send_file
+from flask import render_template, request, redirect, url_for, flash, send_file, abort
 from flask_login import login_required, current_user
 from model import db, Prowadzacy, Zajecia, Uczestnik, Uzytkownik
 from utils import email_do_koordynatora, send_plain_email
@@ -12,7 +12,7 @@ from . import routes_bp
 @login_required
 def admin_dashboard():
     if current_user.role != 'admin':
-        return 'Brak dostępu', 403
+        abort(403)
 
     prowadzacy = Prowadzacy.query.all()
     new_users = (
@@ -39,11 +39,11 @@ def admin_dashboard():
 @login_required
 def usun_zajecie(id):
     if current_user.role != 'admin':
-        return 'Brak dostępu', 403
+        abort(403)
 
     zaj = Zajecia.query.get(id)
     if not zaj:
-        return 'Nie znaleziono zajęć', 404
+        abort(404)
 
     db.session.delete(zaj)
     db.session.commit()
@@ -54,15 +54,15 @@ def usun_zajecie(id):
 @login_required
 def raport(prowadzacy_id):
     if current_user.role != 'admin':
-        return 'Brak dostępu', 403
+        abort(403)
 
     prow = Prowadzacy.query.get(prowadzacy_id)
     if not prow:
-        return 'Nie znaleziono prowadzącego', 404
+        abort(404)
 
     ostatnie = Zajecia.query.filter_by(prowadzacy_id=prowadzacy_id).order_by(Zajecia.data.desc()).first()
     if not ostatnie:
-        return 'Brak zajęć do raportu', 404
+        abort(404)
 
     miesiac = int(request.args.get('miesiac', ostatnie.data.month))
     rok = int(request.args.get('rok', ostatnie.data.year))
@@ -89,7 +89,7 @@ def raport(prowadzacy_id):
 @login_required
 def dodaj_prowadzacego():
     if current_user.role != 'admin':
-        return 'Brak dostępu', 403
+        abort(403)
 
     id_edit = request.form.get('edit_id')
     trener = request.form.get('nowy_trener')
@@ -133,11 +133,11 @@ def dodaj_prowadzacego():
 @login_required
 def usun_prowadzacego(id):
     if current_user.role != 'admin':
-        return 'Brak dostępu', 403
+        abort(403)
 
     prow = Prowadzacy.query.get(id)
     if not prow:
-        return 'Nie znaleziono', 404
+        abort(404)
 
     Uczestnik.query.filter_by(prowadzacy_id=prow.id).delete()
     db.session.delete(prow)
@@ -151,7 +151,7 @@ def usun_prowadzacego(id):
 @login_required
 def approve_user(id):
     if current_user.role != 'admin':
-        return 'Brak dostępu', 403
+        abort(403)
 
     user = Uzytkownik.query.get(id)
     if not user:

--- a/routes/panel.py
+++ b/routes/panel.py
@@ -1,4 +1,4 @@
-from flask import render_template, redirect, url_for, flash, send_file, request
+from flask import render_template, redirect, url_for, flash, send_file, request, abort
 from flask_login import login_required, current_user
 from werkzeug.utils import secure_filename
 from io import BytesIO
@@ -12,11 +12,11 @@ import os
 @login_required
 def panel():
     if current_user.role != 'prowadzacy':
-        return 'Brak dost\u0119pu', 403
+        abort(403)
 
     prow = current_user.prowadzacy
     if not prow:
-        return 'Brak danych prowad\u0105cego', 404
+        abort(404)
 
     uczestnicy = sorted(prow.uczestnicy, key=lambda x: x.imie_nazwisko.lower())
     zajecia = Zajecia.query.filter_by(prowadzacy_id=prow.id).order_by(Zajecia.data.desc()).all()
@@ -27,11 +27,11 @@ def panel():
 @login_required
 def panel_update_profile():
     if current_user.role != 'prowadzacy':
-        return 'Brak dost\u0119pu', 403
+        abort(403)
 
     prow = current_user.prowadzacy
     if not prow:
-        return 'Brak danych', 404
+        abort(404)
 
     prow.imie = request.form.get('imie')
     prow.nazwisko = request.form.get('nazwisko')
@@ -54,11 +54,11 @@ def panel_update_profile():
 @login_required
 def panel_update_participants():
     if current_user.role != 'prowadzacy':
-        return 'Brak dost\u0119pu', 403
+        abort(403)
 
     prow = current_user.prowadzacy
     if not prow:
-        return 'Brak danych', 404
+        abort(404)
 
     lista = request.form.get('uczestnicy')
     prow.uczestnicy.clear()
@@ -77,7 +77,7 @@ def panel_update_participants():
 def pobierz_zajecie(id):
     zaj = Zajecia.query.get(id)
     if not zaj or zaj.prowadzacy_id != current_user.prowadzacy_id:
-        return 'Brak dost\u0119pu', 403
+        abort(403)
 
     prow = current_user.prowadzacy
     obecni = [u.imie_nazwisko for u in zaj.obecni]
@@ -104,7 +104,7 @@ def pobierz_zajecie(id):
 def usun_moje_zajecie(id):
     zaj = Zajecia.query.get(id)
     if not zaj or zaj.prowadzacy_id != current_user.prowadzacy_id:
-        return 'Brak dost\u0119pu', 403
+        abort(403)
 
     db.session.delete(zaj)
     db.session.commit()

--- a/templates/403.html
+++ b/templates/403.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <title>Brak dostępu – ShareOKO</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <div class="container mt-5 mb-5 text-center">
+    <h1 class="display-4">Brak dostępu</h1>
+    <p class="lead">Nie posiadasz uprawnień do tej strony.</p>
+    <a href="{{ url_for('routes.index') }}" class="btn btn-primary mt-3">Powrót do strony głównej</a>
+  </div>
+</body>
+</html>

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <title>Nie znaleziono – ShareOKO</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <div class="container mt-5 mb-5 text-center">
+    <h1 class="display-4">Nie znaleziono strony</h1>
+    <p class="lead">Przepraszamy, podany adres nie istnieje.</p>
+    <a href="{{ url_for('routes.index') }}" class="btn btn-primary mt-3">Powrót do strony głównej</a>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add templates for 403 and 404 responses
- register error handlers in `app.py`
- use `abort(403)` and `abort(404)` in panel and admin routes

## Testing
- `python -m py_compile app.py routes/admin.py routes/panel.py`

------
https://chatgpt.com/codex/tasks/task_e_684467624df8832ab20485f9f20938b0