### PR TITLE
Add env template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+SECRET_KEY=your-secret-key
+ADMIN_LOGIN=admin
+ADMIN_PASSWORD=changeme
+EMAIL_RECIPIENT=coord@example.com
+SMTP_HOST=smtp.example.com
+SMTP_PORT=465
+EMAIL_LOGIN=user@example.com
+EMAIL_PASSWORD=pass

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ instance/
 *.sock
 *.db
 .env.*
+!.env.example
 *.db-journal
 
 # Pliki z podpisami i szablonami (jeśli nie chcesz ich commitować)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This is a small Flask application for managing attendance.
 
 ## Environment variables
 
-The application expects several settings to be provided through environment variables:
+The application expects several settings to be provided through environment variables.
+Copy `.env.example` to `.env` and adjust the values, or export them manually:
 
 - `SECRET_KEY` – secret used by Flask for sessions.
 - `ADMIN_LOGIN` – login of the administrator account created by `init_db.py`.
@@ -16,7 +17,7 @@ The application expects several settings to be provided through environment vari
   - `EMAIL_LOGIN` – SMTP user name.
   - `EMAIL_PASSWORD` – SMTP password.
 
-You can export them in your shell or put them in an `.env` file when using docker-compose.
+You can export them in your shell or copy `.env.example` to `.env` when using docker-compose.
 
 ## Database setup
 


### PR DESCRIPTION
## Summary
- provide a `.env.example` containing all configuration variables
- track this example in git
- mention the example file in the docs for setup

## Testing
- `python -m py_compile app.py init_db.py utils.py model.py doc_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_684469236da4832a92fa7929d58f6df6