### PR TITLE
Add DATABASE_URL override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 SECRET_KEY=your-secret-key
 ADMIN_LOGIN=admin
 ADMIN_PASSWORD=changeme
+DATABASE_URL=sqlite:///obecnosc.db
 EMAIL_RECIPIENT=coord@example.com
 SMTP_HOST=smtp.example.com
 SMTP_PORT=465

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Copy `.env.example` to `.env` and adjust the values, or export them manually:
 - `SECRET_KEY` – secret used by Flask for sessions.
 - `ADMIN_LOGIN` – login of the administrator account created by `init_db.py`.
 - `ADMIN_PASSWORD` – password for the administrator account.
+- `DATABASE_URL` – optional database URI (default `sqlite:///obecnosc.db`).
 - Mail configuration used when sending attendance lists and reports:
   - `EMAIL_RECIPIENT` – address of the coordinator receiving emails.
   - `SMTP_HOST` – SMTP server hostname.

--- a/app.py
+++ b/app.py
@@ -20,7 +20,9 @@ def create_app():
 
     # Konfiguracja aplikacji
     app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", "dev")
-    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///obecnosc.db"
+    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv(
+        "DATABASE_URL", "sqlite:///obecnosc.db"
+    )
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
     # Inicjalizacja rozszerzeń


### PR DESCRIPTION
## Summary
- allow overriding DB connection via `DATABASE_URL`
- document the new variable in README
- provide default value in `.env.example`

## Testing
- `python -m py_compile app.py init_db.py model.py utils.py routes/*.py doc_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_684479428174832a9eaed1666deca774