### PR TITLE
Handle e-mail errors

### DIFF
--- a/routes/attendance.py
+++ b/routes/attendance.py
@@ -4,6 +4,10 @@ from model import Prowadzacy
 
 from utils import przetworz_liste_obecnosci, email_do_koordynatora
 from . import routes_bp
+import smtplib
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @routes_bp.route('/', methods=['GET', 'POST'])
@@ -72,8 +76,12 @@ def index():
                         download_name=f'lista_{data_str}.docx',
                     )
                 elif akcja == 'wyslij':
-                    email_do_koordynatora(buf, data_str, typ='lista')
-                    flash('Lista została wysłana e-mailem', 'success')
+                    try:
+                        email_do_koordynatora(buf, data_str, typ='lista')
+                        flash('Lista została wysłana e-mailem', 'success')
+                    except smtplib.SMTPException:
+                        logger.exception('Failed to send attendance email')
+                        flash('Nie udało się wysłać e-maila', 'danger')
                     return redirect(url_for('routes.index'))
 
     return render_template('index.html',

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -6,7 +6,11 @@ from model import db, Uzytkownik, Prowadzacy, Uczestnik
 from utils import send_plain_email
 import os
 import uuid
+import smtplib
+import logging
 from . import routes_bp
+
+logger = logging.getLogger(__name__)
 
 @routes_bp.route("/login", methods=["GET", "POST"])
 def login():
@@ -80,11 +84,15 @@ def register():
         db.session.add(user)
         db.session.commit()
 
-        send_plain_email(
-            "kontakt@vestmedia.pl",
-            "Nowa rejestracja prowadzącego",
-            f"Zarejestrował się {imie} {nazwisko} (login: {login_val})."
-        )
+        try:
+            send_plain_email(
+                "kontakt@vestmedia.pl",
+                "Nowa rejestracja prowadzącego",
+                f"Zarejestrował się {imie} {nazwisko} (login: {login_val})."
+            )
+        except smtplib.SMTPException:
+            logger.exception('Failed to send registration email')
+            flash('Nie udało się wysłać e-maila', 'danger')
 
         flash("Rejestracja zakończona. Poczekaj na zatwierdzenie konta.", "success")
         return redirect(url_for("routes.login"))

--- a/utils.py
+++ b/utils.py
@@ -87,8 +87,9 @@ def email_do_koordynatora(buf, data, typ="lista"):
                 smtp.login(login, password)
                 smtp.send_message(msg)
         logger.info("Mail sent to %s", odbiorca)
-    except Exception as e:
+    except smtplib.SMTPException as e:
         logger.exception("Failed to send email: %s", e)
+        raise
 
 
 def send_plain_email(to_addr: str, subject: str, body: str) -> None:
@@ -115,5 +116,6 @@ def send_plain_email(to_addr: str, subject: str, body: str) -> None:
                 smtp.login(login, password)
                 smtp.send_message(msg)
         logger.info("Mail sent to %s", to_addr)
-    except Exception as e:
+    except smtplib.SMTPException as e:
         logger.exception("Failed to send email: %s", e)
+        raise


### PR DESCRIPTION
## Summary
- catch `smtplib` errors in mail helpers and re-raise
- log and flash a message when sending mail from routes fails

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684479d9e064832a9108b31638584c9b