### PR TITLE
Fix admin delete route integer parameter

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -137,7 +137,7 @@ def dodaj_prowadzacego():
     flash('Prowadzący zapisany', 'success')
     return redirect(url_for('routes.admin_dashboard'))
 
-@routes_bp.route('/usun/<id>', methods=['POST'])
+@routes_bp.route('/usun/<int:id>', methods=['POST'])
 @login_required
 def usun_prowadzacego(id):
     if current_user.role != 'admin':


### PR DESCRIPTION
## Summary
- enforce integer parameter in the admin `/usun` route
- ensure other routes already use `<int>` parameters consistently

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684488f3bd40832aaa3ad7397969a26d