### PR TITLE
Add validation for signature image uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ Remember to set `FLASK_APP=app:create_app` before running Flask commands.
 ## Templates
 
 The files `szablon.docx` (attendance template) and `rejestr.docx` (monthly report template) must be present in the project root. They are ignored by Git so provide your own copies.
+
+## Signature images
+
+Only PNG and JPG files are accepted when uploading signature images in the admin
+or trainer panels. Files with other extensions or MIME types will be rejected.

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -12,6 +12,9 @@ from . import routes_bp
 
 logger = logging.getLogger(__name__)
 
+ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg"}
+ALLOWED_MIME_TYPES = {"image/png", "image/jpeg"}
+
 @routes_bp.route('/admin')
 @login_required
 def admin_dashboard():
@@ -122,8 +125,15 @@ def dodaj_prowadzacego():
         db.session.add(prow)
         db.session.flush()
 
+    sanitized = None
     if podpis and podpis.filename:
         sanitized = secure_filename(podpis.filename)
+        ext = sanitized.rsplit('.', 1)[-1].lower()
+        if ext not in ALLOWED_EXTENSIONS or podpis.mimetype not in ALLOWED_MIME_TYPES:
+            flash('Nieobsługiwany format pliku podpisu. Dozwolone są PNG i JPG.', 'danger')
+            return redirect(url_for('routes.admin_dashboard'))
+
+    if podpis and sanitized:
         filename = f"{prow.id}_{sanitized}"
         path = os.path.join('static', filename)
         podpis.save(path)

--- a/routes/panel.py
+++ b/routes/panel.py
@@ -7,6 +7,9 @@ from doc_generator import generuj_liste_obecnosci
 from . import routes_bp
 import os
 
+ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg"}
+ALLOWED_MIME_TYPES = {"image/png", "image/jpeg"}
+
 
 @routes_bp.route('/panel')
 @login_required
@@ -38,8 +41,15 @@ def panel_update_profile():
     prow.numer_umowy = request.form.get('numer_umowy')
 
     podpis = request.files.get('podpis')
+    sanitized = None
     if podpis and podpis.filename:
         sanitized = secure_filename(podpis.filename)
+        ext = sanitized.rsplit('.', 1)[-1].lower()
+        if ext not in ALLOWED_EXTENSIONS or podpis.mimetype not in ALLOWED_MIME_TYPES:
+            flash('Nieobsługiwany format pliku podpisu. Dozwolone są PNG i JPG.', 'danger')
+            return redirect(url_for('routes.panel'))
+
+    if podpis and sanitized:
         filename = f"{prow.id}_{sanitized}"
         path = os.path.join('static', filename)
         podpis.save(path)


### PR DESCRIPTION
## Summary
- validate signature images in admin and panel routes
- document allowed formats in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684489b15830832a8354fdbdef0abe6c