### PR TITLE
Add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Ignore version control and development files
+.git
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Virtual environments and env files
+.env
+*.env
+!.env.example
+
+# IDE and editor folders
+.vscode/
+.idea/
+
+# Local data and logs
+instance/
+*.db
+*.db-journal
+*.sqlite3
+*.log
+*.pid
+*.sock
+*.tmp
+*.bak
+*.swp
+
+# Migrations are not needed inside the image
+migrations/
+
+# Misc system files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Copy `.env.example` to `.env` and adjust the values, or export them manually:
 
 You can export them in your shell or copy `.env.example` to `.env` when using docker-compose.
 
+A `.dockerignore` file keeps the image small by skipping development files like `.git` and the `migrations` directory when building.
+
 ## Database setup
 
 Install the required packages first:


### PR DESCRIPTION
## Summary
- avoid shipping dev files in Docker builds with `.dockerignore`
- mention new file in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68448c86799c832a8cb7a7e8bd6c03b0