### PR TITLE
Pełne imię i nazwisko w aplikacji

### DIFF
--- a/doc_generator.py
+++ b/doc_generator.py
@@ -42,7 +42,7 @@ def generuj_raport_miesieczny(prowadzacy, zajecia, szablon_path, podpis_dir, mie
 
     for para in doc.paragraphs:
         if "zleceniobiorca:" in para.text.lower():
-            para.text = f"Zleceniobiorca: {prowadzacy.nazwisko}"
+            para.text = f"Zleceniobiorca: {prowadzacy.imie} {prowadzacy.nazwisko}"
         elif "zlecenia nr" in para.text.lower():
             para.text = f"Rozliczenie liczby godzin wykonywania usług do umowy zlecenia nr {prowadzacy.numer_umowy}"
         elif para.text.strip().lower().startswith("w "):

--- a/routes/panel.py
+++ b/routes/panel.py
@@ -95,7 +95,7 @@ def pobierz_zajecie(id):
         zaj.data.strftime('%Y-%m-%d'),
         str(zaj.czas_trwania).replace('.', ','),
         obecni,
-        prow.nazwisko,
+        f"{prow.imie} {prow.nazwisko}",
         os.path.join('static', prow.podpis_filename)
     )
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -73,7 +73,7 @@
         {% for p in prowadzacy %}
         <tr>
           <td>{{ p.id }}</td>
-          <td>{{ p.nazwisko }}</td>
+          <td>{{ p.imie }} {{ p.nazwisko }}</td>
           <td>
             {% if p.podpis_filename %}
               <img src="{{ url_for('static', filename=p.podpis_filename) }}" alt="Podpis" style="height: 40px;">
@@ -89,7 +89,7 @@
             </ul>
           </td>
           <td class="text-nowrap">
-            <button class="btn btn-sm" onclick="edytujProwadzacego({{ p.id }}, '{{ p.nazwisko }}', '{{ p.numer_umowy }}', [{% for u in p.uczestnicy %}'{{ u.imie_nazwisko }}'{% if not loop.last %}, {% endif %}{% endfor %}])">
+            <button class="btn btn-sm" onclick="edytujProwadzacego({{ p.id }}, '{{ p.imie }} {{ p.nazwisko }}', '{{ p.numer_umowy }}', [{% for u in p.uczestnicy %}'{{ u.imie_nazwisko }}'{% if not loop.last %}, {% endif %}{% endfor %}])">
               <i class="bi bi-pencil"></i>
             </button>
             <form action="{{ url_for('routes.usun_prowadzacego', id=p.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć?')">
@@ -152,7 +152,7 @@
         <tr>
           <td>{{ z.data }}</td>
           <td>{{ z.czas_trwania }}</td>
-          <td>{{ z.prowadzacy.nazwisko }}</td>
+          <td>{{ z.prowadzacy.imie }} {{ z.prowadzacy.nazwisko }}</td>
           <td>
             <ul class="mb-0">
               {% for o in z.obecni %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,7 +46,7 @@
           <label for="prowadzący" class="form-label">Wybierz prowadzącego:</label>
           <select name="prowadzący" id="prowadzący" class="form-select" required aria-required="true">
             {% for p in prowadzacy %}
-              <option value="{{ p.id }}" {% if selected == p.id %}selected{% endif %}>{{ p.nazwisko }}</option>
+              <option value="{{ p.id }}" {% if selected == p.id %}selected{% endif %}>{{ p.imie }} {{ p.nazwisko }}</option>
             {% endfor %}
           </select>
         </div>

--- a/utils.py
+++ b/utils.py
@@ -22,7 +22,7 @@ def przetworz_liste_obecnosci(form, wybrany):
         data_str,
         czas,
         sorted([ucz.imie_nazwisko for ucz in obecni_uczestnicy], key=str.lower),
-        wybrany.nazwisko,
+        f"{wybrany.imie} {wybrany.nazwisko}",
         os.path.join("static", wybrany.podpis_filename)
     )
 


### PR DESCRIPTION
## Summary
- show trainer full name in admin and index views
- include first name in generated documents
- pass first and last name when building attendance list

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449198642c832abcd0509a18f89366