### PR TITLE
Validate email addresses on login

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The application expects several settings to be provided through environment vari
 Copy `.env.example` to `.env` and adjust the values, or export them manually:
 
 - `SECRET_KEY` – secret used by Flask for sessions.
-- `ADMIN_LOGIN` – login of the administrator account created by `init_db.py`.
+- `ADMIN_LOGIN` – e-mail address of the administrator account created by `init_db.py`.
 - `ADMIN_PASSWORD` – password for the administrator account.
 - `DATABASE_URL` – optional database URI (default `sqlite:///obecnosc.db`).
 - Mail configuration used when sending attendance lists and reports:
@@ -52,3 +52,10 @@ The files `szablon.docx` (attendance template) and `rejestr.docx` (monthly repor
 
 Only PNG and JPG files are accepted when uploading signature images in the admin
 or trainer panels. Files with other extensions or MIME types will be rejected.
+
+## Login format
+
+All user logins are e-mail addresses. The administrator login specified by
+`ADMIN_LOGIN` and the login provided during trainer registration must be valid
+e-mail addresses. The application will reject invalid addresses during
+registration and login.

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -3,7 +3,7 @@ from flask_login import login_user, logout_user, login_required
 from werkzeug.security import check_password_hash, generate_password_hash
 from werkzeug.utils import secure_filename
 from model import db, Uzytkownik, Prowadzacy, Uczestnik
-from utils import send_plain_email
+from utils import send_plain_email, is_valid_email
 import os
 import uuid
 import smtplib
@@ -17,6 +17,10 @@ def login():
     if request.method == "POST":
         login_val = request.form.get("login")
         haslo = request.form.get("hasło")
+
+        if not is_valid_email(login_val):
+            flash("Login musi być prawidłowym adresem e-mail", "danger")
+            return redirect(url_for("routes.login"))
 
         user = Uzytkownik.query.filter_by(login=login_val).first()
         if user and check_password_hash(user.haslo_hash, haslo):
@@ -54,6 +58,10 @@ def register():
 
         if not all([imie, nazwisko, numer_umowy, lista_uczestnikow, login_val, haslo]):
             flash("Wszystkie pola oprócz podpisu są wymagane", "danger")
+            return redirect(url_for("routes.register"))
+
+        if not is_valid_email(login_val):
+            flash("Login musi być prawidłowym adresem e-mail", "danger")
             return redirect(url_for("routes.register"))
 
         if Uzytkownik.query.filter_by(login=login_val).first():

--- a/templates/login.html
+++ b/templates/login.html
@@ -29,7 +29,7 @@
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="mb-3">
         <label for="login" class="form-label">Login:</label>
-        <input type="text" class="form-control" id="login" name="login" required>
+        <input type="email" class="form-control" id="login" name="login" required>
       </div>
       <div class="mb-3">
         <label for="hasło" class="form-label">Hasło:</label>

--- a/templates/register.html
+++ b/templates/register.html
@@ -27,8 +27,8 @@
         <textarea class="form-control" id="lista_uczestnikow" name="lista_uczestnikow" rows="5" required></textarea>
       </div>
       <div class="mb-3">
-        <label for="login" class="form-label">Login:</label>
-        <input type="text" class="form-control" id="login" name="login" required>
+        <label for="login" class="form-label">Login (adres e-mail):</label>
+        <input type="email" class="form-control" id="login" name="login" required>
       </div>
       <div class="mb-3">
         <label for="haslo" class="form-label">Hasło:</label>

--- a/utils.py
+++ b/utils.py
@@ -6,8 +6,18 @@ import os
 import smtplib
 import logging
 from email.message import EmailMessage
+import re
 
 logger = logging.getLogger(__name__)
+
+EMAIL_REGEX = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def is_valid_email(value: str) -> bool:
+    """Return True if ``value`` looks like a valid e-mail address."""
+    if not isinstance(value, str):
+        return False
+    return bool(EMAIL_REGEX.match(value))
 
 def przetworz_liste_obecnosci(form, wybrany):
     data_str = form.get("data")


### PR DESCRIPTION
## Summary
- add `utils.is_valid_email` helper
- reject invalid email addresses during login and registration
- mark login fields as `type="email"`
- document that all logins must be valid emails

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844945db24c832aad70c06139574928