### PR TITLE
Add approval link to admin emails

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -165,7 +165,7 @@ def usun_prowadzacego(id):
     return redirect(url_for('routes.admin_dashboard'))
 
 
-@routes_bp.route('/approve_user/<int:id>', methods=['POST'])
+@routes_bp.route('/approve_user/<int:id>', methods=['POST', 'GET'])
 @login_required
 def approve_user(id):
     if current_user.role != 'admin':

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -93,10 +93,14 @@ def register():
         db.session.commit()
 
         try:
+            approve_link = url_for(
+                "routes.approve_user", id=user.id, _external=True
+            )
             send_plain_email(
                 "kontakt@vestmedia.pl",
                 "Nowa rejestracja prowadzącego",
-                f"Zarejestrował się {imie} {nazwisko} (login: {login_val})."
+                f"Zarejestrował się {imie} {nazwisko} (login: {login_val}).\n"
+                f"Potwierdź konto tutaj: {approve_link}"
             )
         except smtplib.SMTPException:
             logger.exception('Failed to send registration email')


### PR DESCRIPTION
## Summary
- include approval link in registration emails to admins
- allow GET requests on `/approve_user/<id>`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844961c5b5c832aa5f8db500510228b