### PR TITLE
Improve accessibility of templates

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -7,6 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
 </head>
 <body class="bg-light">
+  <a href="#main" class="visually-hidden-focusable">Przejdź do głównej zawartości</a>
 
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container-fluid">
@@ -18,7 +19,7 @@
     </div>
   </nav>
 
-  <main class="container mt-5 mb-5">
+  <main id="main" class="container mt-5 mb-5">
     {% if new_users %}
     <h2 class="mb-4">Konta oczekujące na zatwierdzenie</h2>
     <table class="table table-bordered align-middle">
@@ -89,14 +90,14 @@
             </ul>
           </td>
           <td class="text-nowrap">
-            <button class="btn btn-sm" onclick="edytujProwadzacego({{ p.id }}, '{{ p.imie }} {{ p.nazwisko }}', '{{ p.numer_umowy }}', [{% for u in p.uczestnicy %}'{{ u.imie_nazwisko }}'{% if not loop.last %}, {% endif %}{% endfor %}])">
+            <button class="btn btn-sm" onclick="edytujProwadzacego({{ p.id }}, '{{ p.imie }} {{ p.nazwisko }}', '{{ p.numer_umowy }}', [{% for u in p.uczestnicy %}'{{ u.imie_nazwisko }}'{% if not loop.last %}, {% endif %}{% endfor %}])" aria-label="Edytuj prowadzącego">
               <i class="bi bi-pencil"></i>
             </button>
             <form action="{{ url_for('routes.usun_prowadzacego', id=p.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć?')">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-              <button type="submit" class="btn btn-sm text-danger"><i class="bi bi-trash"></i></button>
+              <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń prowadzącego"><i class="bi bi-trash"></i></button>
             </form>
-            <button class="btn btn-sm text-primary" data-bs-toggle="modal" data-bs-target="#raportModal{{ p.id }}">
+            <button class="btn btn-sm text-primary" data-bs-toggle="modal" data-bs-target="#raportModal{{ p.id }}" aria-label="Raport miesięczny">
               <i class="bi bi-file-earmark-text"></i>
             </button>
           </td>
@@ -163,7 +164,7 @@
           <td>
             <form action="{{ url_for('routes.usun_zajecie', id=z.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć zajęcia?')">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-              <button type="submit" class="btn btn-sm text-danger"><i class="bi bi-trash"></i></button>
+              <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń zajęcia"><i class="bi bi-trash"></i></button>
             </form>
           </td>
         </tr>

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,6 +18,7 @@
   </style>
 </head>
 <body class="bg-light">
+  <a href="#main" class="visually-hidden-focusable">Przejdź do głównej zawartości</a>
 
   <!-- Ikony w prawym górnym rogu -->
   <div class="position-absolute top-0 end-0 d-flex flex-column align-items-end m-3" style="z-index: 10;">
@@ -27,7 +28,7 @@
     {% endif %}
   </div>
 
-  <main class="container mt-5 mb-5">
+  <main id="main" class="container mt-5 mb-5">
     <h1 class="mb-4 text-center">Lista obecności – ShareOKO</h1>
 
     {% with messages = get_flashed_messages(with_categories=True) %}
@@ -50,7 +51,7 @@
             {% endfor %}
           </select>
         </div>
-        <button type="button" class="btn btn-outline-success ms-3" style="white-space: nowrap;" data-bs-toggle="modal" data-bs-target="#dodajModal">
+        <button type="button" class="btn btn-outline-success ms-3" style="white-space: nowrap;" data-bs-toggle="modal" data-bs-target="#dodajModal" aria-label="Dodaj prowadzącego">
           <i class="bi bi-person-plus"></i>
         </button>
       </div>

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -7,6 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
 </head>
 <body class="bg-light">
+  <a href="#main" class="visually-hidden-focusable">Przejdź do głównej zawartości</a>
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container-fluid">
       <span class="navbar-brand">Panel prowadzącego</span>
@@ -16,7 +17,7 @@
     </div>
   </nav>
 
-  <main class="container mt-5 mb-5">
+  <main id="main" class="container mt-5 mb-5">
     {% with messages = get_flashed_messages(with_categories=True) %}
       {% if messages %}
         {% for category, message in messages %}
@@ -84,10 +85,10 @@
             </ul>
           </td>
           <td class="text-nowrap">
-            <a href="{{ url_for('routes.pobierz_zajecie', id=z.id) }}" class="btn btn-sm text-primary"><i class="bi bi-download"></i></a>
+            <a href="{{ url_for('routes.pobierz_zajecie', id=z.id) }}" class="btn btn-sm text-primary" aria-label="Pobierz dokument"><i class="bi bi-download"></i></a>
             <form action="{{ url_for('routes.usun_moje_zajecie', id=z.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Usunąć zajęcia?')">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-              <button type="submit" class="btn btn-sm text-danger"><i class="bi bi-trash"></i></button>
+              <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń zajęcia"><i class="bi bi-trash"></i></button>
             </form>
           </td>
         </tr>


### PR DESCRIPTION
## Summary
- add skip to content links in `index.html`, `admin.html` and `panel.html`
- label all icon-only buttons with `aria-label`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684496e566b4832a818f4785ded914ca