### PR TITLE
Remove dev SECRET_KEY fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a small Flask application for managing attendance.
 The application expects several settings to be provided through environment variables.
 Copy `.env.example` to `.env` and adjust the values, or export them manually:
 
-- `SECRET_KEY` – secret used by Flask for sessions.
+- `SECRET_KEY` – secret used by Flask for sessions. The application will fail to start if this variable is not set.
 - `ADMIN_LOGIN` – e-mail address of the administrator account created by `init_db.py`.
 - `ADMIN_PASSWORD` – password for the administrator account.
 - `DATABASE_URL` – optional database URI (default `sqlite:///obecnosc.db`).

--- a/app.py
+++ b/app.py
@@ -19,7 +19,10 @@ def create_app():
     app = Flask(__name__)
 
     # Konfiguracja aplikacji
-    app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", "dev")
+    secret_key = os.getenv("SECRET_KEY")
+    if not secret_key:
+        raise RuntimeError("SECRET_KEY environment variable must be set")
+    app.config["SECRET_KEY"] = secret_key
     app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv(
         "DATABASE_URL", "sqlite:///obecnosc.db"
     )


### PR DESCRIPTION
## Summary
- fail fast if `SECRET_KEY` is missing
- document `SECRET_KEY` requirement

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6844983aedc8832aa0c90ab12b501c6e