### PR TITLE
Refactor allowed file type constants

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -1,7 +1,12 @@
 from flask import render_template, request, redirect, url_for, flash, send_file, abort
 from flask_login import login_required, current_user
 from model import db, Prowadzacy, Zajecia, Uczestnik, Uzytkownik
-from utils import email_do_koordynatora, send_plain_email
+from utils import (
+    email_do_koordynatora,
+    send_plain_email,
+    ALLOWED_EXTENSIONS,
+    ALLOWED_MIME_TYPES,
+)
 from doc_generator import generuj_raport_miesieczny
 from io import BytesIO
 from werkzeug.utils import secure_filename
@@ -11,9 +16,6 @@ import logging
 from . import routes_bp
 
 logger = logging.getLogger(__name__)
-
-ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg"}
-ALLOWED_MIME_TYPES = {"image/png", "image/jpeg"}
 
 @routes_bp.route('/admin')
 @login_required

--- a/routes/panel.py
+++ b/routes/panel.py
@@ -6,9 +6,7 @@ from model import db, Uczestnik, Zajecia
 from doc_generator import generuj_liste_obecnosci
 from . import routes_bp
 import os
-
-ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg"}
-ALLOWED_MIME_TYPES = {"image/png", "image/jpeg"}
+from utils import ALLOWED_EXTENSIONS, ALLOWED_MIME_TYPES
 
 
 @routes_bp.route('/panel')

--- a/utils.py
+++ b/utils.py
@@ -12,6 +12,10 @@ logger = logging.getLogger(__name__)
 
 EMAIL_REGEX = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
+# Allowed signature upload formats
+ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg"}
+ALLOWED_MIME_TYPES = {"image/png", "image/jpeg"}
+
 
 def is_valid_email(value: str) -> bool:
     """Return True if ``value`` looks like a valid e-mail address."""


### PR DESCRIPTION
## Summary
- centralize allowed signature file types in `utils.py`
- import allowed file type constants from `utils` in admin and panel routes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68449a776f28832ab860dfd739326dfa