### PR TITLE
Split trainer name fields

### DIFF
--- a/migrations/versions/24f8fe5b09bb_split_full_name.py
+++ b/migrations/versions/24f8fe5b09bb_split_full_name.py
@@ -1,0 +1,51 @@
+"""split full name into first and last
+
+Revision ID: 24f8fe5b09bb
+Revises: a022a779868c
+Create Date: 2025-06-07 17:30:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '24f8fe5b09bb'
+down_revision = 'a022a779868c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    prowadzacy = sa.table(
+        'prowadzacy',
+        sa.column('id', sa.Integer),
+        sa.column('imie', sa.String),
+        sa.column('nazwisko', sa.String),
+    )
+    result = conn.execute(sa.select(prowadzacy.c.id, prowadzacy.c.nazwisko))
+    for row in result:
+        if row.nazwisko:
+            imie, _, nazwisko = row.nazwisko.partition(' ')
+            conn.execute(
+                prowadzacy.update()
+                .where(prowadzacy.c.id == row.id)
+                .values(imie=imie, nazwisko=nazwisko)
+            )
+
+
+def downgrade():
+    conn = op.get_bind()
+    prowadzacy = sa.table(
+        'prowadzacy',
+        sa.column('id', sa.Integer),
+        sa.column('imie', sa.String),
+        sa.column('nazwisko', sa.String),
+    )
+    result = conn.execute(sa.select(prowadzacy.c.id, prowadzacy.c.imie, prowadzacy.c.nazwisko))
+    for row in result:
+        full = ' '.join(filter(None, [row.imie, row.nazwisko]))
+        conn.execute(
+            prowadzacy.update()
+            .where(prowadzacy.c.id == row.id)
+            .values(imie=None, nazwisko=full)
+        )
+

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -106,12 +106,13 @@ def dodaj_prowadzacego():
         abort(403)
 
     id_edit = request.form.get('edit_id')
-    trener = request.form.get('nowy_trener')
+    imie = request.form.get('nowy_imie')
+    nazwisko = request.form.get('nowy_nazwisko')
     numer_umowy = request.form.get('nowy_umowa')
     uczestnicy = request.form.get('nowi_uczestnicy')
     podpis = request.files.get('nowy_podpis')
 
-    if not trener or not uczestnicy:
+    if not imie or not nazwisko or not uczestnicy:
         flash('Wszystkie pola są wymagane', 'danger')
         return redirect(url_for('routes.admin_dashboard'))
 
@@ -120,11 +121,12 @@ def dodaj_prowadzacego():
         if not prow:
             flash('Nie znaleziono prowadącego', 'danger')
             return redirect(url_for('routes.admin_dashboard'))
-        prow.nazwisko = trener
+        prow.imie = imie
+        prow.nazwisko = nazwisko
         prow.numer_umowy = numer_umowy
         prow.uczestnicy.clear()
     else:
-        prow = Prowadzacy(nazwisko=trener, numer_umowy=numer_umowy)
+        prow = Prowadzacy(imie=imie, nazwisko=nazwisko, numer_umowy=numer_umowy)
         db.session.add(prow)
         db.session.flush()
 
@@ -147,8 +149,8 @@ def dodaj_prowadzacego():
         podpis.save(path)
         prow.podpis_filename = filename
 
-    for nazwisko in uczestnicy.strip().splitlines():
-        uczestnik = Uczestnik(prowadzacy_id=prow.id, imie_nazwisko=nazwisko)
+    for nazw in uczestnicy.strip().splitlines():
+        uczestnik = Uczestnik(prowadzacy_id=prow.id, imie_nazwisko=nazw)
         db.session.add(uczestnik)
 
     db.session.commit()

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -90,7 +90,7 @@
             </ul>
           </td>
           <td class="text-nowrap">
-            <button class="btn btn-sm" onclick="edytujProwadzacego({{ p.id }}, '{{ p.imie }} {{ p.nazwisko }}', '{{ p.numer_umowy }}', [{% for u in p.uczestnicy %}'{{ u.imie_nazwisko }}'{% if not loop.last %}, {% endif %}{% endfor %}])" aria-label="Edytuj prowadzącego">
+            <button class="btn btn-sm" onclick="edytujProwadzacego({{ p.id }}, '{{ p.imie }}', '{{ p.nazwisko }}', '{{ p.numer_umowy }}', [{% for u in p.uczestnicy %}'{{ u.imie_nazwisko }}'{% if not loop.last %}, {% endif %}{% endfor %}])" aria-label="Edytuj prowadzącego">
               <i class="bi bi-pencil"></i>
             </button>
             <form action="{{ url_for('routes.usun_prowadzacego', id=p.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć?')">
@@ -185,8 +185,12 @@
           <div class="modal-body">
             <input type="hidden" name="edit_id" id="edit_id">
             <div class="mb-3">
-              <label for="nowy_trener" class="form-label">Imię i nazwisko prowadzącego:</label>
-              <input type="text" class="form-control" id="nowy_trener" name="nowy_trener" required>
+              <label for="nowy_imie" class="form-label">Imię prowadzącego:</label>
+              <input type="text" class="form-control" id="nowy_imie" name="nowy_imie" required>
+            </div>
+            <div class="mb-3">
+              <label for="nowy_nazwisko" class="form-label">Nazwisko prowadzącego:</label>
+              <input type="text" class="form-control" id="nowy_nazwisko" name="nowy_nazwisko" required>
             </div>
             <div class="mb-3">
               <label for="nowy_umowa" class="form-label">Numer umowy:</label>
@@ -211,9 +215,10 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script>
-    function edytujProwadzacego(id, nazwisko, umowa, uczestnicy) {
+    function edytujProwadzacego(id, imie, nazwisko, umowa, uczestnicy) {
       document.getElementById("edit_id").value = id;
-      document.getElementById("nowy_trener").value = nazwisko;
+      document.getElementById("nowy_imie").value = imie;
+      document.getElementById("nowy_nazwisko").value = nazwisko;
       document.getElementById("nowy_umowa").value = umowa;
       document.getElementById("nowi_uczestnicy").value = uczestnicy.join("\n");
       const modal = new bootstrap.Modal(document.getElementById('dodajModal'));

--- a/templates/index.html
+++ b/templates/index.html
@@ -103,8 +103,12 @@
             <div class="modal-body">
               <input type="hidden" name="edit_id" id="edit_id">
               <div class="mb-3">
-                <label for="nowy_trener" class="form-label">Imię i nazwisko prowadzącego:</label>
-                <input type="text" class="form-control" id="nowy_trener" name="nowy_trener" required>
+                <label for="nowy_imie" class="form-label">Imię prowadzącego:</label>
+                <input type="text" class="form-control" id="nowy_imie" name="nowy_imie" required>
+              </div>
+              <div class="mb-3">
+                <label for="nowy_nazwisko" class="form-label">Nazwisko prowadzącego:</label>
+                <input type="text" class="form-control" id="nowy_nazwisko" name="nowy_nazwisko" required>
               </div>
               <div class="mb-3">
                 <label for="nowy_umowa" class="form-label">Numer umowy:</label>


### PR DESCRIPTION
## Summary
- add first/last name inputs to admin and index trainer modals
- adjust `edytujProwadzacego()` to fill new fields
- update `/dodaj` route to handle `nowy_imie` and `nowy_nazwisko`
- data migration splitting existing names into first and last columns

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68449ddb092c832a8c5de7f0e9a6b9dd