### PR TITLE
Implement password reset feature

### DIFF
--- a/model.py
+++ b/model.py
@@ -1,5 +1,6 @@
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import UserMixin
+from datetime import datetime
 
 
 
@@ -57,6 +58,16 @@ class Uzytkownik(UserMixin, db.Model):
     prowadzacy_id = db.Column(db.Integer, db.ForeignKey("prowadzacy.id"))
 
     prowadzacy = db.relationship("Prowadzacy", back_populates="user")
+
+
+class PasswordResetToken(db.Model):
+    __tablename__ = "password_reset_token"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("uzytkownik.id"), nullable=False)
+    token = db.Column(db.String, unique=True, nullable=False)
+    expires_at = db.Column(db.DateTime, nullable=False)
+
+    user = db.relationship("Uzytkownik")
 
 def init_db(app):
     with app.app_context():

--- a/templates/reset_form.html
+++ b/templates/reset_form.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <title>Nowe hasło – ShareOKO</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <div class="container mt-5" style="max-width: 400px;">
+    <h2 class="mb-4 text-center">Ustaw nowe hasło</h2>
+    <form method="POST">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="mb-3">
+        <label for="password" class="form-label">Nowe hasło:</label>
+        <input type="password" class="form-control" id="password" name="password" required>
+      </div>
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          {% for category, message in messages %}
+            <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+      <div class="d-grid">
+        <button type="submit" class="btn btn-primary">Zmień hasło</button>
+      </div>
+    </form>
+  </div>
+</body>
+</html>

--- a/templates/reset_request.html
+++ b/templates/reset_request.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <title>Reset hasła – ShareOKO</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <div class="container mt-5" style="max-width: 400px;">
+    <h2 class="mb-4 text-center">Reset hasła</h2>
+    <form method="POST">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="mb-3">
+        <label for="login" class="form-label">Adres e-mail:</label>
+        <input type="email" class="form-control" id="login" name="login" required>
+      </div>
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          {% for category, message in messages %}
+            <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+      <div class="d-grid">
+        <button type="submit" class="btn btn-primary">Wyślij link</button>
+      </div>
+    </form>
+    <div class="text-center mt-3">
+      <a href="{{ url_for('routes.login') }}">Powrót do logowania</a>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `PasswordResetToken` model
- implement `/reset-request` and `/reset/<token>` routes
- send reset links via email and expire tokens after use
- log token creation and password resets
- add password reset templates

## Testing
- `python -m py_compile routes/auth.py model.py utils.py app.py init_db.py`
- `python -m py_compile routes/admin.py routes/attendance.py routes/panel.py`

------
https://chatgpt.com/codex/tasks/task_e_68449f57b4b4832aa004be044ee598ba