### PR TITLE
Add return link for trainers

### DIFF
--- a/templates/panel.html
+++ b/templates/panel.html
@@ -12,6 +12,7 @@
     <div class="container-fluid">
       <span class="navbar-brand">Panel prowadzącego</span>
       <div class="d-flex">
+        <a href="{{ url_for('routes.index') }}" class="btn btn-outline-light me-2">Powrót</a>
         <a href="{{ url_for('routes.logout') }}" class="btn btn-outline-light">Wyloguj</a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a "Powrót" button in the trainer panel navbar to return to the start page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684476f6be94832a8fc26c874392b560