### PR TITLE
Handle missing Setting table

### DIFF
--- a/templates/panel.html
+++ b/templates/panel.html
@@ -12,6 +12,7 @@
     <div class="container-fluid">
       <span class="navbar-brand">Panel prowadzącego</span>
       <div class="d-flex">
+        <a href="{{ url_for('routes.index') }}" class="btn btn-outline-light me-2">Powrót</a>
         <a href="{{ url_for('routes.logout') }}" class="btn btn-outline-light">Wyloguj</a>
       </div>
     </div>

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 from model import db, Zajecia, Uczestnik
+from sqlalchemy.exc import OperationalError
 from doc_generator import generuj_liste_obecnosci
 from io import BytesIO
 from datetime import datetime
@@ -25,7 +26,13 @@ def load_db_settings(app) -> None:
     from model import Setting  # imported lazily to avoid circular imports
 
     with app.app_context():
-        for setting in Setting.query.all():
+        try:
+            settings = Setting.query.all()
+        except OperationalError:
+            logger.warning("Settings table missing, skipping load.")
+            settings = []
+
+        for setting in settings:
             os.environ.setdefault(setting.key.upper(), setting.value)
 
     global SIGNATURE_MAX_SIZE


### PR DESCRIPTION
## Summary
- avoid crashing when database doesn't yet contain the `setting` table

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684476f6be94832a8fc26c874392b560