### PR TITLE
Add base template with theme support

### DIFF
--- a/templates/403.html
+++ b/templates/403.html
@@ -1,15 +1,9 @@
-<!DOCTYPE html>
-<html lang="pl">
-<head>
-  <meta charset="UTF-8">
-  <title>Brak dostępu – ShareOKO</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
+{% extends 'base.html' %}
+{% block title %}Brak dostępu{% endblock %}
+{% block content %}
   <div class="container mt-5 mb-5 text-center">
     <h1 class="display-4">Brak dostępu</h1>
     <p class="lead">Nie posiadasz uprawnień do tej strony.</p>
     <a href="{{ url_for('routes.index') }}" class="btn btn-primary mt-3">Powrót do strony głównej</a>
   </div>
-</body>
-</html>
+{% endblock %}

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,15 +1,9 @@
-<!DOCTYPE html>
-<html lang="pl">
-<head>
-  <meta charset="UTF-8">
-  <title>Nie znaleziono – ShareOKO</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
+{% extends 'base.html' %}
+{% block title %}Nie znaleziono{% endblock %}
+{% block content %}
   <div class="container mt-5 mb-5 text-center">
     <h1 class="display-4">Nie znaleziono strony</h1>
     <p class="lead">Przepraszamy, podany adres nie istnieje.</p>
     <a href="{{ url_for('routes.index') }}" class="btn btn-primary mt-3">Powrót do strony głównej</a>
   </div>
-</body>
-</html>
+{% endblock %}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,178 +1,157 @@
-<!DOCTYPE html>
-<html lang="pl">
-<head>
-  <meta charset="UTF-8">
-  <title>Panel administratora – ShareOKO</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-</head>
-<body class="bg-light">
-  <a href="#main" class="visually-hidden-focusable">Przejdź do głównej zawartości</a>
+{% extends 'base.html' %}
+{% block title %}Panel administratora{% endblock %}
+{% block content %}
+  {% if new_users %}
+  <h2 class="mb-4">Konta oczekujące na zatwierdzenie</h2>
+  <table class="table table-bordered align-middle">
+    <thead class="table-warning">
+      <tr>
+        <th>ID</th>
+        <th>Login</th>
+        <th>Imię i nazwisko</th>
+        <th>Akcja</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for u in new_users %}
+      <tr>
+        <td>{{ u.id }}</td>
+        <td>{{ u.login }}</td>
+        <td>{{ u.prowadzacy.imie }} {{ u.prowadzacy.nazwisko }}</td>
+        <td>
+          <form action="{{ url_for('routes.approve_user', id=u.id) }}" method="POST" class="d-inline">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="btn btn-sm btn-success">Akceptuj</button>
+          </form>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <hr class="my-4">
+  {% endif %}
 
-  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-    <div class="container-fluid">
-      <span class="navbar-brand">Panel administratora</span>
-      <div class="d-flex">
-        <a href="{{ url_for('routes.index') }}" class="btn btn-outline-light me-2">Powrót</a>
-        <a href="{{ url_for('routes.admin_settings') }}" class="btn btn-outline-light me-2">Ustawienia</a>
-        <a href="{{ url_for('routes.logout') }}" class="btn btn-outline-danger">Wyloguj</a>
-      </div>
-    </div>
-  </nav>
+  <h2 class="mb-4">Lista prowadzących</h2>
 
-  <main id="main" class="container mt-5 mb-5">
-    {% if new_users %}
-    <h2 class="mb-4">Konta oczekujące na zatwierdzenie</h2>
-    <table class="table table-bordered align-middle">
-      <thead class="table-warning">
-        <tr>
-          <th>ID</th>
-          <th>Login</th>
-          <th>Imię i nazwisko</th>
-          <th>Akcja</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for u in new_users %}
-        <tr>
-          <td>{{ u.id }}</td>
-          <td>{{ u.login }}</td>
-          <td>{{ u.prowadzacy.imie }} {{ u.prowadzacy.nazwisko }}</td>
-          <td>
-            <form action="{{ url_for('routes.approve_user', id=u.id) }}" method="POST" class="d-inline">
-              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-              <button type="submit" class="btn btn-sm btn-success">Akceptuj</button>
-            </form>
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-    <hr class="my-4">
+  {% with messages = get_flashed_messages(with_categories=True) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="alert alert-{{ category }} mt-3" role="alert">{{ message }}</div>
+      {% endfor %}
     {% endif %}
+  {% endwith %}
 
-    <h2 class="mb-4">Lista prowadzących</h2>
+  <table class="table table-striped table-bordered align-middle">
+    <thead class="table-dark">
+      <tr>
+        <th>ID</th>
+        <th>Imię i nazwisko</th>
+        <th>Podpis</th>
+        <th>Uczestnicy</th>
+        <th>Akcje</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for p in prowadzacy %}
+      <tr>
+        <td>{{ p.id }}</td>
+        <td>{{ p.imie }} {{ p.nazwisko }}</td>
+        <td>
+          {% if p.podpis_filename %}
+            <img src="{{ url_for('static', filename=p.podpis_filename) }}" alt="Podpis" style="height: 40px;">
+          {% else %}
+            Brak
+          {% endif %}
+        </td>
+        <td>
+          <ul class="mb-0">
+            {% for u in p.uczestnicy %}
+              <li>{{ u.imie_nazwisko }}</li>
+            {% endfor %}
+          </ul>
+        </td>
+        <td class="text-nowrap">
+          <button class="btn btn-sm" onclick="edytujProwadzacego({{ p.id }}, '{{ p.imie }}', '{{ p.nazwisko }}', '{{ p.numer_umowy }}', [{% for u in p.uczestnicy %}'{{ u.imie_nazwisko }}'{% if not loop.last %}, {% endif %}{% endfor %}])" aria-label="Edytuj prowadzącego">
+            <i class="bi bi-pencil"></i>
+          </button>
+          <form action="{{ url_for('routes.usun_prowadzacego', id=p.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć?')">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń prowadzącego"><i class="bi bi-trash"></i></button>
+          </form>
+          <button class="btn btn-sm text-primary" data-bs-toggle="modal" data-bs-target="#raportModal{{ p.id }}" aria-label="Raport miesięczny">
+            <i class="bi bi-file-earmark-text"></i>
+          </button>
+        </td>
+      </tr>
 
-    {% with messages = get_flashed_messages(with_categories=True) %}
-      {% if messages %}
-        {% for category, message in messages %}
-          <div class="alert alert-{{ category }} mt-3" role="alert">{{ message }}</div>
-        {% endfor %}
-      {% endif %}
-    {% endwith %}
-
-    <table class="table table-striped table-bordered align-middle">
-      <thead class="table-dark">
-        <tr>
-          <th>ID</th>
-          <th>Imię i nazwisko</th>
-          <th>Podpis</th>
-          <th>Uczestnicy</th>
-          <th>Akcje</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for p in prowadzacy %}
-        <tr>
-          <td>{{ p.id }}</td>
-          <td>{{ p.imie }} {{ p.nazwisko }}</td>
-          <td>
-            {% if p.podpis_filename %}
-              <img src="{{ url_for('static', filename=p.podpis_filename) }}" alt="Podpis" style="height: 40px;">
-            {% else %}
-              Brak
-            {% endif %}
-          </td>
-          <td>
-            <ul class="mb-0">
-              {% for u in p.uczestnicy %}
-                <li>{{ u.imie_nazwisko }}</li>
-              {% endfor %}
-            </ul>
-          </td>
-          <td class="text-nowrap">
-            <button class="btn btn-sm" onclick="edytujProwadzacego({{ p.id }}, '{{ p.imie }}', '{{ p.nazwisko }}', '{{ p.numer_umowy }}', [{% for u in p.uczestnicy %}'{{ u.imie_nazwisko }}'{% if not loop.last %}, {% endif %}{% endfor %}])" aria-label="Edytuj prowadzącego">
-              <i class="bi bi-pencil"></i>
-            </button>
-            <form action="{{ url_for('routes.usun_prowadzacego', id=p.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć?')">
+      <div class="modal fade" id="raportModal{{ p.id }}" tabindex="-1" aria-labelledby="raportModalLabel{{ p.id }}" aria-hidden="true">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <form method="GET" action="{{ url_for('routes.raport', prowadzacy_id=p.id) }}">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-              <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń prowadzącego"><i class="bi bi-trash"></i></button>
+              <div class="modal-header">
+                <h5 class="modal-title" id="raportModalLabel{{ p.id }}">Raport miesięczny</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>
+              </div>
+              <div class="modal-body">
+                <div class="mb-3">
+                  <label for="miesiac{{ p.id }}" class="form-label">Miesiąc:</label>
+                  <input type="number" class="form-control" id="miesiac{{ p.id }}" name="miesiac" value="{{ ostatnie[p.id].month if p.id in ostatnie }}" required>
+                </div>
+                <div class="mb-3">
+                  <label for="rok{{ p.id }}" class="form-label">Rok:</label>
+                  <input type="number" class="form-control" id="rok{{ p.id }}" name="rok" value="{{ ostatnie[p.id].year if p.id in ostatnie }}" required>
+                </div>
+              </div>
+              <div class="modal-footer">
+                <button type="submit" class="btn btn-primary">Pobierz</button>
+                <button type="submit" name="wyslij" value="1" class="btn btn-outline-secondary">Wyślij mailem</button>
+              </div>
             </form>
-            <button class="btn btn-sm text-primary" data-bs-toggle="modal" data-bs-target="#raportModal{{ p.id }}" aria-label="Raport miesięczny">
-              <i class="bi bi-file-earmark-text"></i>
-            </button>
-          </td>
-        </tr>
-
-        <div class="modal fade" id="raportModal{{ p.id }}" tabindex="-1" aria-labelledby="raportModalLabel{{ p.id }}" aria-hidden="true">
-          <div class="modal-dialog">
-            <div class="modal-content">
-              <form method="GET" action="{{ url_for('routes.raport', prowadzacy_id=p.id) }}">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <div class="modal-header">
-                  <h5 class="modal-title" id="raportModalLabel{{ p.id }}">Raport miesięczny</h5>
-                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>
-                </div>
-                <div class="modal-body">
-                  <div class="mb-3">
-                    <label for="miesiac{{ p.id }}" class="form-label">Miesiąc:</label>
-                    <input type="number" class="form-control" id="miesiac{{ p.id }}" name="miesiac" value="{{ ostatnie[p.id].month if p.id in ostatnie }}" required>
-                  </div>
-                  <div class="mb-3">
-                    <label for="rok{{ p.id }}" class="form-label">Rok:</label>
-                    <input type="number" class="form-control" id="rok{{ p.id }}" name="rok" value="{{ ostatnie[p.id].year if p.id in ostatnie }}" required>
-                  </div>
-                </div>
-                <div class="modal-footer">
-                  <button type="submit" class="btn btn-primary">Pobierz</button>
-                  <button type="submit" name="wyslij" value="1" class="btn btn-outline-secondary">Wyślij mailem</button>
-                </div>
-              </form>
-            </div>
           </div>
         </div>
-        {% endfor %}
-      </tbody>
-    </table>
+      </div>
+      {% endfor %}
+    </tbody>
+  </table>
 
-    <hr class="my-5">
+  <hr class="my-5">
 
-    <h2 class="mb-4">Historia zajęć</h2>
+  <h2 class="mb-4">Historia zajęć</h2>
 
-    <table class="table table-striped table-hover">
-      <thead class="table-secondary">
-        <tr>
-          <th>Data</th>
-          <th>Czas trwania</th>
-          <th>Prowadzący</th>
-          <th>Obecni</th>
-          <th>Akcja</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for z in zajecia %}
-        <tr>
-          <td>{{ z.data }}</td>
-          <td>{{ z.czas_trwania }}</td>
-          <td>{{ z.prowadzacy.imie }} {{ z.prowadzacy.nazwisko }}</td>
-          <td>
-            <ul class="mb-0">
-              {% for o in z.obecni %}
-                <li>{{ o.imie_nazwisko }}</li>
-              {% endfor %}
-            </ul>
-          </td>
-          <td>
-            <form action="{{ url_for('routes.usun_zajecie', id=z.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć zajęcia?')">
-              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-              <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń zajęcia"><i class="bi bi-trash"></i></button>
-            </form>
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </main>
+  <table class="table table-striped table-hover">
+    <thead class="table-secondary">
+      <tr>
+        <th>Data</th>
+        <th>Czas trwania</th>
+        <th>Prowadzący</th>
+        <th>Obecni</th>
+        <th>Akcja</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for z in zajecia %}
+      <tr>
+        <td>{{ z.data }}</td>
+        <td>{{ z.czas_trwania }}</td>
+        <td>{{ z.prowadzacy.imie }} {{ z.prowadzacy.nazwisko }}</td>
+        <td>
+          <ul class="mb-0">
+            {% for o in z.obecni %}
+              <li>{{ o.imie_nazwisko }}</li>
+            {% endfor %}
+          </ul>
+        </td>
+        <td>
+          <form action="{{ url_for('routes.usun_zajecie', id=z.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć zajęcia?')">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń zajęcia"><i class="bi bi-trash"></i></button>
+          </form>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
 
   <div class="modal fade" id="dodajModal" tabindex="-1" aria-labelledby="dodajModalLabel" aria-hidden="true">
     <div class="modal-dialog">
@@ -213,8 +192,8 @@
       </div>
     </div>
   </div>
-
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+{% endblock %}
+{% block scripts %}
   <script>
     function edytujProwadzacego(id, imie, nazwisko, umowa, uczestnicy) {
       document.getElementById("edit_id").value = id;
@@ -226,5 +205,4 @@
       modal.show();
     }
   </script>
-</body>
-</html>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="pl" data-bs-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <title>{% block title %}ShareOKO{% endblock %}</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+  {% block head_extra %}{% endblock %}
+</head>
+<body class="bg-light">
+  <a href="#main" class="visually-hidden-focusable">Przejdź do głównej zawartości</a>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container-fluid justify-content-end gap-2">
+      <a href="{{ url_for('routes.index') }}" class="btn btn-outline-light">Powrót</a>
+      {% if is_admin %}
+      <a href="{{ url_for('routes.admin_settings') }}" class="btn btn-outline-light">Ustawienia</a>
+      {% endif %}
+      {% if current_user.is_authenticated %}
+      <a href="{{ url_for('routes.logout') }}" class="btn btn-outline-danger">Wyloguj</a>
+      {% endif %}
+      <button class="btn btn-outline-light" id="themeToggle" onclick="toggleTheme()" aria-label="Przełącz motyw">🌓</button>
+    </div>
+  </nav>
+  <main id="main" class="container mt-5 mb-5">
+    {% block content %}{% endblock %}
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    function applyTheme(t) {
+      document.documentElement.setAttribute('data-bs-theme', t);
+    }
+    function toggleTheme() {
+      const current = document.documentElement.getAttribute('data-bs-theme') === 'dark';
+      const next = current ? 'light' : 'dark';
+      applyTheme(next);
+      localStorage.setItem('theme', next);
+    }
+    (function() {
+      let theme = localStorage.getItem('theme');
+      if (!theme) {
+        theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      }
+      applyTheme(theme);
+    })();
+  </script>
+  {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,10 +1,6 @@
-<!DOCTYPE html>
-<html lang="pl">
-<head>
-  <meta charset="UTF-8">
-  <title>Lista obecności – ShareOKO</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+{% extends 'base.html' %}
+{% block title %}Lista obecności{% endblock %}
+{% block head_extra %}
   <style>
     body {
       background-color: #f4f4f8;
@@ -16,124 +12,116 @@
       font-size: 1.2rem;
     }
   </style>
-</head>
-<body class="bg-light">
-  <a href="#main" class="visually-hidden-focusable">Przejdź do głównej zawartości</a>
-
-  <!-- Ikony w prawym górnym rogu -->
-  <div class="position-absolute top-0 end-0 d-flex flex-column align-items-end m-3" style="z-index: 10;">
-    <button class="btn btn-sm btn-outline-dark mb-2" onclick="toggleTheme()" id="themeToggle" aria-label="Przełącz tryb ciemny/jasny">🌓</button>
-    {% if current_user.role == 'prowadzacy' %}
-    <a href="{{ url_for('routes.panel') }}" class="btn btn-sm btn-dark">Panel</a>
-    {% endif %}
+{% endblock %}
+{% block content %}
+  {% if current_user.role == 'prowadzacy' %}
+  <div class="d-flex justify-content-end mb-3">
+    <a href="{{ url_for('routes.panel') }}" class="btn btn-dark">Panel</a>
   </div>
+  {% endif %}
+  <h1 class="mb-4 text-center">Lista obecności – ShareOKO</h1>
 
-  <main id="main" class="container mt-5 mb-5">
-    <h1 class="mb-4 text-center">Lista obecności – ShareOKO</h1>
+  {% with messages = get_flashed_messages(with_categories=True) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="alert alert-{{ category }} mt-3" role="alert">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
 
-    {% with messages = get_flashed_messages(with_categories=True) %}
-      {% if messages %}
-        {% for category, message in messages %}
-          <div class="alert alert-{{ category }} mt-3" role="alert">{{ message }}</div>
-        {% endfor %}
-      {% endif %}
-    {% endwith %}
-
-    <form method="POST" enctype="multipart/form-data" aria-label="Formularz listy obecności">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      {% if is_admin %}
-      <div class="mb-3 d-flex justify-content-between align-items-center">
-        <div class="w-100">
-          <label for="prowadzący" class="form-label">Wybierz prowadzącego:</label>
-          <select name="prowadzący" id="prowadzący" class="form-select" required aria-required="true">
-            {% for p in prowadzacy %}
-              <option value="{{ p.id }}" {% if selected == p.id %}selected{% endif %}>{{ p.imie }} {{ p.nazwisko }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <button type="button" class="btn btn-outline-success ms-3" style="white-space: nowrap;" data-bs-toggle="modal" data-bs-target="#dodajModal" aria-label="Dodaj prowadzącego">
-          <i class="bi bi-person-plus"></i>
-        </button>
-      </div>
-      {% else %}
-      <input type="hidden" name="prowadzący" value="{{ selected }}">
-      {% endif %}
-
-      <div class="mb-3">
-        <label for="data" class="form-label">Data zajęć:</label>
-        <input type="date" name="data" id="data" class="form-control" required>
-      </div>
-
-      <div class="mb-3">
-        <label for="czas" class="form-label">Czas trwania zajęć:</label>
-        <input type="text" name="czas" id="czas" class="form-control" value="{{ domyslny_czas }}" required>
-      </div>
-
-      <fieldset class="mb-3" aria-labelledby="uczestnicy-label">
-        <legend id="uczestnicy-label">Lista uczestników (zaznacz obecnych):</legend>
-        {% for osoba in uczestnicy %}
-          <div class="form-check">
-            <input class="form-check-input" type="checkbox" name="obecny" id="check{{ loop.index }}" value="{{ osoba.id }}">
-            <label class="form-check-label" for="check{{ loop.index }}">{{ osoba.imie_nazwisko }}</label>
-          </div>
-        {% endfor %}
-      </fieldset>
-
-      <div class="text-center d-flex flex-column flex-sm-row justify-content-center gap-3">
-        <button type="submit" name="akcja" value="wyslij" class="btn btn-primary">
-          Wyślij do koordynatora
-        </button>
-        <button type="submit" name="akcja" value="pobierz" class="btn btn-outline-secondary">
-          Pobierz dokument
-        </button>
-      </div>
-
-    </form>
-
+  <form method="POST" enctype="multipart/form-data" aria-label="Formularz listy obecności">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     {% if is_admin %}
-    <div class="modal fade" id="dodajModal" tabindex="-1" aria-labelledby="dodajModalLabel" aria-hidden="true">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <form method="POST" action="/dodaj" enctype="multipart/form-data">
-              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <div class="modal-header">
-              <h5 class="modal-title" id="dodajModalLabel">Dodaj / Edytuj prowadzącego</h5>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>
-            </div>
-            <div class="modal-body">
-              <input type="hidden" name="edit_id" id="edit_id">
-              <div class="mb-3">
-                <label for="nowy_imie" class="form-label">Imię prowadzącego:</label>
-                <input type="text" class="form-control" id="nowy_imie" name="nowy_imie" required>
-              </div>
-              <div class="mb-3">
-                <label for="nowy_nazwisko" class="form-label">Nazwisko prowadzącego:</label>
-                <input type="text" class="form-control" id="nowy_nazwisko" name="nowy_nazwisko" required>
-              </div>
-              <div class="mb-3">
-                <label for="nowy_umowa" class="form-label">Numer umowy:</label>
-                <input type="text" class="form-control" id="nowy_umowa" name="nowy_umowa" required>
-              </div>
-              <div class="mb-3">
-                <label for="nowi_uczestnicy" class="form-label">Uczestnicy (po jednym na linię):</label>
-                <textarea class="form-control" id="nowi_uczestnicy" name="nowi_uczestnicy" rows="5" required></textarea>
-              </div>
-              <div class="mb-3">
-                <label for="nowy_podpis" class="form-label">Plik podpisu (.png lub .jpg):</label>
-                <input class="form-control" type="file" name="nowy_podpis" id="nowy_podpis" accept=".png,.jpg,.jpeg">
-              </div>
-            </div>
-            <div class="modal-footer">
-              <button type="submit" class="btn btn-success">Zapisz prowadzącego</button>
-            </div>
-          </form>
+    <div class="mb-3 d-flex justify-content-between align-items-center">
+      <div class="w-100">
+        <label for="prowadzący" class="form-label">Wybierz prowadzącego:</label>
+        <select name="prowadzący" id="prowadzący" class="form-select" required aria-required="true">
+          {% for p in prowadzacy %}
+            <option value="{{ p.id }}" {% if selected == p.id %}selected{% endif %}>{{ p.imie }} {{ p.nazwisko }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <button type="button" class="btn btn-outline-success ms-3" style="white-space: nowrap;" data-bs-toggle="modal" data-bs-target="#dodajModal" aria-label="Dodaj prowadzącego">
+        <i class="bi bi-person-plus"></i>
+      </button>
+    </div>
+    {% else %}
+    <input type="hidden" name="prowadzący" value="{{ selected }}">
+    {% endif %}
+
+    <div class="mb-3">
+      <label for="data" class="form-label">Data zajęć:</label>
+      <input type="date" name="data" id="data" class="form-control" required>
+    </div>
+
+    <div class="mb-3">
+      <label for="czas" class="form-label">Czas trwania zajęć:</label>
+      <input type="text" name="czas" id="czas" class="form-control" value="{{ domyslny_czas }}" required>
+    </div>
+
+    <fieldset class="mb-3" aria-labelledby="uczestnicy-label">
+      <legend id="uczestnicy-label">Lista uczestników (zaznacz obecnych):</legend>
+      {% for osoba in uczestnicy %}
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="obecny" id="check{{ loop.index }}" value="{{ osoba.id }}">
+          <label class="form-check-label" for="check{{ loop.index }}">{{ osoba.imie_nazwisko }}</label>
         </div>
+      {% endfor %}
+    </fieldset>
+
+    <div class="text-center d-flex flex-column flex-sm-row justify-content-center gap-3">
+      <button type="submit" name="akcja" value="wyslij" class="btn btn-primary">
+        Wyślij do koordynatora
+      </button>
+      <button type="submit" name="akcja" value="pobierz" class="btn btn-outline-secondary">
+        Pobierz dokument
+      </button>
+    </div>
+  </form>
+
+  {% if is_admin %}
+  <div class="modal fade" id="dodajModal" tabindex="-1" aria-labelledby="dodajModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form method="POST" action="/dodaj" enctype="multipart/form-data">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <div class="modal-header">
+            <h5 class="modal-title" id="dodajModalLabel">Dodaj / Edytuj prowadzącego</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>
+          </div>
+          <div class="modal-body">
+            <input type="hidden" name="edit_id" id="edit_id">
+            <div class="mb-3">
+              <label for="nowy_imie" class="form-label">Imię prowadzącego:</label>
+              <input type="text" class="form-control" id="nowy_imie" name="nowy_imie" required>
+            </div>
+            <div class="mb-3">
+              <label for="nowy_nazwisko" class="form-label">Nazwisko prowadzącego:</label>
+              <input type="text" class="form-control" id="nowy_nazwisko" name="nowy_nazwisko" required>
+            </div>
+            <div class="mb-3">
+              <label for="nowy_umowa" class="form-label">Numer umowy:</label>
+              <input type="text" class="form-control" id="nowy_umowa" name="nowy_umowa" required>
+            </div>
+            <div class="mb-3">
+              <label for="nowi_uczestnicy" class="form-label">Uczestnicy (po jednym na linię):</label>
+              <textarea class="form-control" id="nowi_uczestnicy" name="nowi_uczestnicy" rows="5" required></textarea>
+            </div>
+            <div class="mb-3">
+              <label for="nowy_podpis" class="form-label">Plik podpisu (.png lub .jpg):</label>
+              <input class="form-control" type="file" name="nowy_podpis" id="nowy_podpis" accept=".png,.jpg,.jpeg">
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="submit" class="btn btn-success">Zapisz prowadzącego</button>
+          </div>
+        </form>
       </div>
     </div>
-    {% endif %}
-  </main>
+  </div>
+  {% endif %}
 
-  <footer class="text-center text-white bg-dark py-4">
+  <footer class="text-center text-white bg-dark py-4 mt-5">
     <small>
       <i class="bi bi-globe"></i>
       <a href="https://vestmedia.pl" target="_blank" class="text-light text-decoration-underline">vestmedia.pl</a>
@@ -142,32 +130,10 @@
       <a href="mailto:kontakt@vestmedia.pl" class="text-light text-decoration-underline">kontakt@vestmedia.pl</a>
     </small>
   </footer>
-
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+{% endblock %}
+{% block scripts %}
   <script>
-    function toggleTheme() {
-      const html = document.documentElement;
-      const dark = html.classList.toggle('dark-mode');
-      document.body.classList.toggle('bg-dark');
-      document.body.classList.toggle('text-light');
-      document.getElementById("themeToggle").classList.toggle('btn-outline-light');
-      document.getElementById("themeToggle").classList.toggle('btn-outline-dark');
-      localStorage.setItem("theme", dark ? "dark" : "light");
-      const inputs = document.querySelectorAll('.form-control, .form-select, .form-check-input');
-      inputs.forEach(el => el.classList.toggle('bg-secondary'));
-    }
-
     document.getElementById("data").valueAsDate = new Date();
-
-    if (!localStorage.getItem("theme")) {
-      if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-        toggleTheme();
-      }
-    }
-    if (localStorage.getItem("theme") === "dark") {
-      toggleTheme();
-    }
-
     {% if is_admin %}
     document.getElementById("prowadzący").addEventListener("change", () => {
       const form = document.querySelector("form");
@@ -180,5 +146,4 @@
     });
     {% endif %}
   </script>
-</body>
-</html>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,9 +1,6 @@
-<!DOCTYPE html>
-<html lang="pl">
-<head>
-  <meta charset="UTF-8">
-  <title>Logowanie – ShareOKO</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+{% extends 'base.html' %}
+{% block title %}Logowanie{% endblock %}
+{% block head_extra %}
   <style>
     body {
       background-color: #f4f4f8;
@@ -21,8 +18,8 @@
       box-shadow: 0 0 10px rgba(0,0,0,0.1);
     }
   </style>
-</head>
-<body>
+{% endblock %}
+{% block content %}
   <div class="login-box">
     <h2 class="mb-4 text-center">Logowanie</h2>
     <form method="POST" action="/login">
@@ -50,5 +47,4 @@
       <a href="{{ url_for('routes.register') }}">Zarejestruj się</a>
     </div>
   </div>
-</body>
-</html>
+{% endblock %}

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -1,103 +1,81 @@
-<!DOCTYPE html>
-<html lang="pl">
-<head>
-  <meta charset="UTF-8">
-  <title>Panel prowadzącego – ShareOKO</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-</head>
-<body class="bg-light">
-  <a href="#main" class="visually-hidden-focusable">Przejdź do głównej zawartości</a>
-  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-    <div class="container-fluid">
-      <span class="navbar-brand">Panel prowadzącego</span>
-      <div class="d-flex">
-        <a href="{{ url_for('routes.index') }}" class="btn btn-outline-light me-2">Powrót</a>
-        <a href="{{ url_for('routes.logout') }}" class="btn btn-outline-light">Wyloguj</a>
+{% extends 'base.html' %}
+{% block title %}Panel prowadzącego{% endblock %}
+{% block content %}
+  {% with messages = get_flashed_messages(with_categories=True) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
+  <h2 class="mb-4">Moje dane</h2>
+  <form method="POST" action="{{ url_for('routes.panel_update_profile') }}" enctype="multipart/form-data" class="mb-5">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div class="row g-3">
+      <div class="col-md-4">
+        <label for="imie" class="form-label">Imię:</label>
+        <input type="text" class="form-control" id="imie" name="imie" value="{{ prowadzacy.imie }}">
+      </div>
+      <div class="col-md-4">
+        <label for="nazwisko" class="form-label">Nazwisko:</label>
+        <input type="text" class="form-control" id="nazwisko" name="nazwisko" value="{{ prowadzacy.nazwisko }}">
+      </div>
+      <div class="col-md-4">
+        <label for="numer_umowy" class="form-label">Numer umowy:</label>
+        <input type="text" class="form-control" id="numer_umowy" name="numer_umowy" value="{{ prowadzacy.numer_umowy }}">
+      </div>
+      <div class="col-md-6">
+        <label for="podpis" class="form-label">Podpis (.png/.jpg):</label>
+        <input type="file" class="form-control" id="podpis" name="podpis" accept=".png,.jpg,.jpeg">
       </div>
     </div>
-  </nav>
+    <div class="mt-3">
+      <button type="submit" class="btn btn-primary">Zapisz dane</button>
+    </div>
+  </form>
 
-  <main id="main" class="container mt-5 mb-5">
-    {% with messages = get_flashed_messages(with_categories=True) %}
-      {% if messages %}
-        {% for category, message in messages %}
-          <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
-        {% endfor %}
-      {% endif %}
-    {% endwith %}
-
-    <h2 class="mb-4">Moje dane</h2>
-    <form method="POST" action="{{ url_for('routes.panel_update_profile') }}" enctype="multipart/form-data" class="mb-5">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <div class="row g-3">
-        <div class="col-md-4">
-          <label for="imie" class="form-label">Imię:</label>
-          <input type="text" class="form-control" id="imie" name="imie" value="{{ prowadzacy.imie }}">
-        </div>
-        <div class="col-md-4">
-          <label for="nazwisko" class="form-label">Nazwisko:</label>
-          <input type="text" class="form-control" id="nazwisko" name="nazwisko" value="{{ prowadzacy.nazwisko }}">
-        </div>
-        <div class="col-md-4">
-          <label for="numer_umowy" class="form-label">Numer umowy:</label>
-          <input type="text" class="form-control" id="numer_umowy" name="numer_umowy" value="{{ prowadzacy.numer_umowy }}">
-        </div>
-        <div class="col-md-6">
-          <label for="podpis" class="form-label">Podpis (.png/.jpg):</label>
-          <input type="file" class="form-control" id="podpis" name="podpis" accept=".png,.jpg,.jpeg">
-        </div>
-      </div>
-      <div class="mt-3">
-        <button type="submit" class="btn btn-primary">Zapisz dane</button>
-      </div>
-    </form>
-
-    <h2 class="mb-4">Uczestnicy</h2>
-    <form method="POST" action="{{ url_for('routes.panel_update_participants') }}" class="mb-5">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <div class="mb-3">
-        <textarea class="form-control" name="uczestnicy" rows="5">{% for u in uczestnicy %}{{ u.imie_nazwisko }}{% if not loop.last %}
+  <h2 class="mb-4">Uczestnicy</h2>
+  <form method="POST" action="{{ url_for('routes.panel_update_participants') }}" class="mb-5">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div class="mb-3">
+      <textarea class="form-control" name="uczestnicy" rows="5">{% for u in uczestnicy %}{{ u.imie_nazwisko }}{% if not loop.last %}
 {% endif %}{% endfor %}</textarea>
-      </div>
-      <button type="submit" class="btn btn-primary">Zapisz listę</button>
-    </form>
+    </div>
+    <button type="submit" class="btn btn-primary">Zapisz listę</button>
+  </form>
 
-    <h2 class="mb-4">Historia zajęć</h2>
-    <table class="table table-striped table-hover">
-      <thead class="table-secondary">
-        <tr>
-          <th>Data</th>
-          <th>Czas</th>
-          <th>Obecni</th>
-          <th>Akcja</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for z in zajecia %}
-        <tr>
-          <td>{{ z.data.date() }}</td>
-          <td>{{ z.czas_trwania }}</td>
-          <td>
-            <ul class="mb-0">
-              {% for o in z.obecni %}
-                <li>{{ o.imie_nazwisko }}</li>
-              {% endfor %}
-            </ul>
-          </td>
-          <td class="text-nowrap">
-            <a href="{{ url_for('routes.pobierz_zajecie', id=z.id) }}" class="btn btn-sm text-primary" aria-label="Pobierz dokument"><i class="bi bi-download"></i></a>
-            <form action="{{ url_for('routes.usun_moje_zajecie', id=z.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Usunąć zajęcia?')">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-              <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń zajęcia"><i class="bi bi-trash"></i></button>
-            </form>
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </main>
-
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+  <h2 class="mb-4">Historia zajęć</h2>
+  <table class="table table-striped table-hover">
+    <thead class="table-secondary">
+      <tr>
+        <th>Data</th>
+        <th>Czas</th>
+        <th>Obecni</th>
+        <th>Akcja</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for z in zajecia %}
+      <tr>
+        <td>{{ z.data.date() }}</td>
+        <td>{{ z.czas_trwania }}</td>
+        <td>
+          <ul class="mb-0">
+            {% for o in z.obecni %}
+              <li>{{ o.imie_nazwisko }}</li>
+            {% endfor %}
+          </ul>
+        </td>
+        <td class="text-nowrap">
+          <a href="{{ url_for('routes.pobierz_zajecie', id=z.id) }}" class="btn btn-sm text-primary" aria-label="Pobierz dokument"><i class="bi bi-download"></i></a>
+          <form action="{{ url_for('routes.usun_moje_zajecie', id=z.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Usunąć zajęcia?')">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń zajęcia"><i class="bi bi-trash"></i></button>
+          </form>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,11 +1,6 @@
-<!DOCTYPE html>
-<html lang="pl">
-<head>
-  <meta charset="UTF-8">
-  <title>Rejestracja – ShareOKO</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
+{% extends 'base.html' %}
+{% block title %}Rejestracja{% endblock %}
+{% block content %}
   <div class="container mt-5 mb-5" style="max-width: 600px;">
     <h2 class="mb-4 text-center">Rejestracja prowadzącego</h2>
     <form method="POST" enctype="multipart/form-data">
@@ -53,5 +48,4 @@
       <a href="{{ url_for('routes.login') }}">Powrót do logowania</a>
     </div>
   </div>
-</body>
-</html>
+{% endblock %}

--- a/templates/reset_form.html
+++ b/templates/reset_form.html
@@ -1,11 +1,6 @@
-<!DOCTYPE html>
-<html lang="pl">
-<head>
-  <meta charset="UTF-8">
-  <title>Nowe hasło – ShareOKO</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
+{% extends 'base.html' %}
+{% block title %}Nowe hasło{% endblock %}
+{% block content %}
   <div class="container mt-5" style="max-width: 400px;">
     <h2 class="mb-4 text-center">Ustaw nowe hasło</h2>
     <form method="POST">
@@ -26,5 +21,4 @@
       </div>
     </form>
   </div>
-</body>
-</html>
+{% endblock %}

--- a/templates/reset_request.html
+++ b/templates/reset_request.html
@@ -1,11 +1,6 @@
-<!DOCTYPE html>
-<html lang="pl">
-<head>
-  <meta charset="UTF-8">
-  <title>Reset hasła – ShareOKO</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
+{% extends 'base.html' %}
+{% block title %}Reset hasła{% endblock %}
+{% block content %}
   <div class="container mt-5" style="max-width: 400px;">
     <h2 class="mb-4 text-center">Reset hasła</h2>
     <form method="POST">
@@ -29,5 +24,4 @@
       <a href="{{ url_for('routes.login') }}">Powrót do logowania</a>
     </div>
   </div>
-</body>
-</html>
+{% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,152 +1,133 @@
-<!DOCTYPE html>
-<html lang="pl">
-<head>
-  <meta charset="UTF-8">
-  <title>Ustawienia – ShareOKO</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
-  <a href="#main" class="visually-hidden-focusable">Przejdź do głównej zawartości</a>
-  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-    <div class="container-fluid">
-      <span class="navbar-brand">Ustawienia</span>
-      <div class="d-flex">
-        <a href="{{ url_for('routes.admin_dashboard') }}" class="btn btn-outline-light me-2">Powrót</a>
-        <a href="{{ url_for('routes.logout') }}" class="btn btn-outline-danger">Wyloguj</a>
+{% extends 'base.html' %}
+{% block title %}Ustawienia{% endblock %}
+{% block content %}
+  {% with messages = get_flashed_messages(with_categories=True) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+  <form method="POST">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div class="row g-3">
+      <div class="col-md-6">
+        <label for="smtp_host" class="form-label">SMTP host:</label>
+        <input type="text" class="form-control" id="smtp_host" name="smtp_host" value="{{ values.smtp_host }}">
+      </div>
+      <div class="col-md-6">
+        <label for="smtp_port" class="form-label">SMTP port:</label>
+        <input type="number" class="form-control" id="smtp_port" name="smtp_port" value="{{ values.smtp_port }}">
+      </div>
+      <div class="col-md-6">
+        <label for="email_recipient" class="form-label">Email odbiorcy:</label>
+        <input type="email" class="form-control" id="email_recipient" name="email_recipient" value="{{ values.email_recipient }}">
+      </div>
+      <div class="col-md-6">
+        <label for="max_signature_size" class="form-label">Limit rozmiaru podpisu (bajty):</label>
+        <input type="number" class="form-control" id="max_signature_size" name="max_signature_size" value="{{ values.max_signature_size }}">
+      </div>
+      <div class="col-md-6">
+        <label for="email_sender_name" class="form-label">Nazwa nadawcy:</label>
+        <input type="text" class="form-control" id="email_sender_name" name="email_sender_name" value="{{ values.email_sender_name }}">
+      </div>
+      <div class="col-md-6">
+        <label for="email_login" class="form-label">Login SMTP:</label>
+        <input type="email" class="form-control" id="email_login" name="email_login" value="{{ values.email_login }}">
+      </div>
+      <div class="col-md-6">
+        <label for="email_password" class="form-label">Hasło SMTP:</label>
+        <input type="password" class="form-control" id="email_password" name="email_password" value="{{ values.email_password }}">
+      </div>
+      <div class="col-12">
+        <label for="email_footer" class="form-label">Stopka e-mail:</label>
+        <textarea class="form-control" id="email_footer" name="email_footer" rows="2">{{ values.email_footer }}</textarea>
       </div>
     </div>
-  </nav>
-  <main id="main" class="container mt-5 mb-5">
-    {% with messages = get_flashed_messages(with_categories=True) %}
-      {% if messages %}
-        {% for category, message in messages %}
-          <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
-        {% endfor %}
-      {% endif %}
-    {% endwith %}
-    <form method="POST">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <div class="row g-3">
-        <div class="col-md-6">
-          <label for="smtp_host" class="form-label">SMTP host:</label>
-          <input type="text" class="form-control" id="smtp_host" name="smtp_host" value="{{ values.smtp_host }}">
-        </div>
-        <div class="col-md-6">
-          <label for="smtp_port" class="form-label">SMTP port:</label>
-          <input type="number" class="form-control" id="smtp_port" name="smtp_port" value="{{ values.smtp_port }}">
-        </div>
-        <div class="col-md-6">
-          <label for="email_recipient" class="form-label">Email odbiorcy:</label>
-          <input type="email" class="form-control" id="email_recipient" name="email_recipient" value="{{ values.email_recipient }}">
-        </div>
-        <div class="col-md-6">
-          <label for="max_signature_size" class="form-label">Limit rozmiaru podpisu (bajty):</label>
-          <input type="number" class="form-control" id="max_signature_size" name="max_signature_size" value="{{ values.max_signature_size }}">
-        </div>
-        <div class="col-md-6">
-          <label for="email_sender_name" class="form-label">Nazwa nadawcy:</label>
-          <input type="text" class="form-control" id="email_sender_name" name="email_sender_name" value="{{ values.email_sender_name }}">
-        </div>
-        <div class="col-md-6">
-          <label for="email_login" class="form-label">Login SMTP:</label>
-          <input type="email" class="form-control" id="email_login" name="email_login" value="{{ values.email_login }}">
-        </div>
-        <div class="col-md-6">
-          <label for="email_password" class="form-label">Hasło SMTP:</label>
-          <input type="password" class="form-control" id="email_password" name="email_password" value="{{ values.email_password }}">
-        </div>
-        <div class="col-12">
-          <label for="email_footer" class="form-label">Stopka e-mail:</label>
-          <textarea class="form-control" id="email_footer" name="email_footer" rows="2">{{ values.email_footer }}</textarea>
-        </div>
-      </div>
 
-      <ul class="nav nav-tabs mt-4" id="mailTabs" role="tablist">
-        <li class="nav-item" role="presentation">
-          <button class="nav-link active" id="list-tab" data-bs-toggle="tab" data-bs-target="#list" type="button" role="tab">Lista obecności</button>
-        </li>
-        <li class="nav-item" role="presentation">
-          <button class="nav-link" id="report-tab" data-bs-toggle="tab" data-bs-target="#report" type="button" role="tab">Raport miesięczny</button>
-        </li>
-        <li class="nav-item" role="presentation">
-          <button class="nav-link" id="registration-tab" data-bs-toggle="tab" data-bs-target="#registration" type="button" role="tab">Rejestracja</button>
-        </li>
-        <li class="nav-item" role="presentation">
-          <button class="nav-link" id="activation-tab" data-bs-toggle="tab" data-bs-target="#activation" type="button" role="tab">Aktywacja konta</button>
-        </li>
-        <li class="nav-item" role="presentation">
-          <button class="nav-link" id="reset-tab" data-bs-toggle="tab" data-bs-target="#reset" type="button" role="tab">Reset hasła</button>
-        </li>
-      </ul>
-      <div class="tab-content border border-top-0 p-3" id="mailTabsContent">
-        <div class="tab-pane fade show active" id="list" role="tabpanel">
-          <div class="mb-3">
-            <label for="email_list_subject" class="form-label">Temat:</label>
-            <input type="text" class="form-control" id="email_list_subject" name="email_list_subject" value="{{ values.email_list_subject }}">
-          </div>
-          <div class="mb-3">
-            <label for="email_list_body" class="form-label">Treść:</label>
-            <textarea class="form-control" id="email_list_body" name="email_list_body" rows="2">{{ values.email_list_body }}</textarea>
-          </div>
+    <ul class="nav nav-tabs mt-4" id="mailTabs" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button class="nav-link active" id="list-tab" data-bs-toggle="tab" data-bs-target="#list" type="button" role="tab">Lista obecności</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="report-tab" data-bs-toggle="tab" data-bs-target="#report" type="button" role="tab">Raport miesięczny</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="registration-tab" data-bs-toggle="tab" data-bs-target="#registration" type="button" role="tab">Rejestracja</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="activation-tab" data-bs-toggle="tab" data-bs-target="#activation" type="button" role="tab">Aktywacja konta</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="reset-tab" data-bs-toggle="tab" data-bs-target="#reset" type="button" role="tab">Reset hasła</button>
+      </li>
+    </ul>
+    <div class="tab-content border border-top-0 p-3" id="mailTabsContent">
+      <div class="tab-pane fade show active" id="list" role="tabpanel">
+        <div class="mb-3">
+          <label for="email_list_subject" class="form-label">Temat:</label>
+          <input type="text" class="form-control" id="email_list_subject" name="email_list_subject" value="{{ values.email_list_subject }}">
         </div>
-        <div class="tab-pane fade" id="report" role="tabpanel">
-          <div class="mb-3">
-            <label for="email_report_subject" class="form-label">Temat:</label>
-            <input type="text" class="form-control" id="email_report_subject" name="email_report_subject" value="{{ values.email_report_subject }}">
-          </div>
-          <div class="mb-3">
-            <label for="email_report_body" class="form-label">Treść:</label>
-            <textarea class="form-control" id="email_report_body" name="email_report_body" rows="2">{{ values.email_report_body }}</textarea>
-          </div>
-        </div>
-        <div class="tab-pane fade" id="registration" role="tabpanel">
-          <div class="mb-3">
-            <label for="registration_email_subject" class="form-label">Temat:</label>
-            <input type="text" class="form-control" id="registration_email_subject" name="registration_email_subject" value="{{ values.registration_email_subject }}">
-          </div>
-          <div class="mb-3">
-            <label for="registration_email_body" class="form-label">Treść:</label>
-            <textarea class="form-control" id="registration_email_body" name="registration_email_body" rows="2">{{ values.registration_email_body }}</textarea>
-          </div>
-        </div>
-        <div class="tab-pane fade" id="activation" role="tabpanel">
-          <div class="mb-3">
-            <label for="reg_email_subject" class="form-label">Temat:</label>
-            <input type="text" class="form-control" id="reg_email_subject" name="reg_email_subject" value="{{ values.reg_email_subject }}">
-          </div>
-          <div class="mb-3">
-            <label for="reg_email_body" class="form-label">Treść:</label>
-            <textarea class="form-control" id="reg_email_body" name="reg_email_body" rows="2">{{ values.reg_email_body }}</textarea>
-          </div>
-        </div>
-        <div class="tab-pane fade" id="reset" role="tabpanel">
-          <div class="mb-3">
-            <label for="reset_email_subject" class="form-label">Temat:</label>
-            <input type="text" class="form-control" id="reset_email_subject" name="reset_email_subject" value="{{ values.reset_email_subject }}">
-          </div>
-          <div class="mb-3">
-            <label for="reset_email_body" class="form-label">Treść:</label>
-            <textarea class="form-control" id="reset_email_body" name="reset_email_body" rows="2">{{ values.reset_email_body }}</textarea>
-          </div>
+        <div class="mb-3">
+          <label for="email_list_body" class="form-label">Treść:</label>
+          <textarea class="form-control" id="email_list_body" name="email_list_body" rows="2">{{ values.email_list_body }}</textarea>
         </div>
       </div>
-      <hr class="my-4">
-      <h5>Dane administratora</h5>
-      <div class="row g-3">
-        <div class="col-md-6">
-          <label for="admin_login" class="form-label">Login admina:</label>
-          <input type="email" class="form-control" id="admin_login" name="admin_login" value="{{ admin_login }}">
+      <div class="tab-pane fade" id="report" role="tabpanel">
+        <div class="mb-3">
+          <label for="email_report_subject" class="form-label">Temat:</label>
+          <input type="text" class="form-control" id="email_report_subject" name="email_report_subject" value="{{ values.email_report_subject }}">
         </div>
-        <div class="col-md-6">
-          <label for="admin_password" class="form-label">Nowe hasło:</label>
-          <input type="password" class="form-control" id="admin_password" name="admin_password">
+        <div class="mb-3">
+          <label for="email_report_body" class="form-label">Treść:</label>
+          <textarea class="form-control" id="email_report_body" name="email_report_body" rows="2">{{ values.email_report_body }}</textarea>
         </div>
       </div>
-      <div class="mt-4">
-        <button type="submit" class="btn btn-primary">Zapisz</button>
+      <div class="tab-pane fade" id="registration" role="tabpanel">
+        <div class="mb-3">
+          <label for="registration_email_subject" class="form-label">Temat:</label>
+          <input type="text" class="form-control" id="registration_email_subject" name="registration_email_subject" value="{{ values.registration_email_subject }}">
+        </div>
+        <div class="mb-3">
+          <label for="registration_email_body" class="form-label">Treść:</label>
+          <textarea class="form-control" id="registration_email_body" name="registration_email_body" rows="2">{{ values.registration_email_body }}</textarea>
+        </div>
       </div>
-    </form>
-  </main>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+      <div class="tab-pane fade" id="activation" role="tabpanel">
+        <div class="mb-3">
+          <label for="reg_email_subject" class="form-label">Temat:</label>
+          <input type="text" class="form-control" id="reg_email_subject" name="reg_email_subject" value="{{ values.reg_email_subject }}">
+        </div>
+        <div class="mb-3">
+          <label for="reg_email_body" class="form-label">Treść:</label>
+          <textarea class="form-control" id="reg_email_body" name="reg_email_body" rows="2">{{ values.reg_email_body }}</textarea>
+        </div>
+      </div>
+      <div class="tab-pane fade" id="reset" role="tabpanel">
+        <div class="mb-3">
+          <label for="reset_email_subject" class="form-label">Temat:</label>
+          <input type="text" class="form-control" id="reset_email_subject" name="reset_email_subject" value="{{ values.reset_email_subject }}">
+        </div>
+        <div class="mb-3">
+          <label for="reset_email_body" class="form-label">Treść:</label>
+          <textarea class="form-control" id="reset_email_body" name="reset_email_body" rows="2">{{ values.reset_email_body }}</textarea>
+        </div>
+      </div>
+    </div>
+    <hr class="my-4">
+    <h5>Dane administratora</h5>
+    <div class="row g-3">
+      <div class="col-md-6">
+        <label for="admin_login" class="form-label">Login admina:</label>
+        <input type="email" class="form-control" id="admin_login" name="admin_login" value="{{ admin_login }}">
+      </div>
+      <div class="col-md-6">
+        <label for="admin_password" class="form-label">Nowe hasło:</label>
+        <input type="password" class="form-control" id="admin_password" name="admin_password">
+      </div>
+    </div>
+    <div class="mt-4">
+      <button type="submit" class="btn btn-primary">Zapisz</button>
+    </div>
+  </form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- introduce `base.html` with navbar and theme toggle
- add dark-mode handling script
- refactor all templates to extend `base.html`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844c0c18458832a824d2869b38344fd