### PR TITLE
Add theme and contrast toggles

### DIFF
--- a/static/theme.css
+++ b/static/theme.css
@@ -1,0 +1,16 @@
+body.high-contrast {
+  font-size: 1.2em;
+  background-color: #000 !important;
+  color: #fff !important;
+}
+
+body.high-contrast a {
+  color: #0ff !important;
+}
+
+body.high-contrast .btn {
+  font-size: 1em;
+  background-color: #ff0 !important;
+  color: #000 !important;
+  border-color: #ff0 !important;
+}

--- a/static/theme.js
+++ b/static/theme.js
@@ -1,0 +1,34 @@
+function applyTheme(theme) {
+  document.documentElement.setAttribute('data-bs-theme', theme);
+}
+
+function applyContrast(enabled) {
+  if (enabled) {
+    document.body.classList.add('high-contrast');
+  } else {
+    document.body.classList.remove('high-contrast');
+  }
+}
+
+function toggleTheme() {
+  const current = document.documentElement.getAttribute('data-bs-theme') === 'dark';
+  const next = current ? 'light' : 'dark';
+  applyTheme(next);
+  localStorage.setItem('theme', next);
+}
+
+function toggleContrast() {
+  const active = document.body.classList.toggle('high-contrast');
+  localStorage.setItem('contrast', active ? '1' : '0');
+}
+
+(function() {
+  let theme = localStorage.getItem('theme');
+  if (!theme) {
+    theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  applyTheme(theme);
+
+  const contrast = localStorage.getItem('contrast') === '1';
+  applyContrast(contrast);
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
   <title>{% block title %}ShareOKO{% endblock %}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="{{ url_for('static', filename='theme.css') }}" rel="stylesheet">
   {% block head_extra %}{% endblock %}
 </head>
 <body class="bg-light">
@@ -19,30 +20,14 @@
       <a href="{{ url_for('routes.logout') }}" class="btn btn-outline-danger">Wyloguj</a>
       {% endif %}
       <button class="btn btn-outline-light" id="themeToggle" onclick="toggleTheme()" aria-label="Przełącz motyw">🌓</button>
+      <button class="btn btn-outline-light" id="contrastToggle" onclick="toggleContrast()" aria-label="Wysoki kontrast">⚙️</button>
     </div>
   </nav>
   <main id="main" class="container mt-5 mb-5">
     {% block content %}{% endblock %}
   </main>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-  <script>
-    function applyTheme(t) {
-      document.documentElement.setAttribute('data-bs-theme', t);
-    }
-    function toggleTheme() {
-      const current = document.documentElement.getAttribute('data-bs-theme') === 'dark';
-      const next = current ? 'light' : 'dark';
-      applyTheme(next);
-      localStorage.setItem('theme', next);
-    }
-    (function() {
-      let theme = localStorage.getItem('theme');
-      if (!theme) {
-        theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-      }
-      applyTheme(theme);
-    })();
-  </script>
+  <script src="{{ url_for('static', filename='theme.js') }}"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add new `theme.js` script to persist theme and high-contrast modes
- add CSS rules for a `high-contrast` body class
- integrate toggle buttons into navbar and load static assets

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844c1ee368c832a90969a588039af51