### PR TITLE
Improve form UX with Bootstrap floating labels

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -94,18 +94,18 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>
               </div>
               <div class="modal-body">
-                <div class="mb-3">
-                  <label for="miesiac{{ p.id }}" class="form-label">Miesiąc:</label>
-                  <input type="number" class="form-control" id="miesiac{{ p.id }}" name="miesiac" value="{{ ostatnie[p.id].month if p.id in ostatnie }}" required>
+                <div class="form-floating mb-3">
+                  <input type="number" class="form-control" id="miesiac{{ p.id }}" name="miesiac" placeholder="Miesiąc" value="{{ ostatnie[p.id].month if p.id in ostatnie }}" required tabindex="1">
+                  <label for="miesiac{{ p.id }}">Miesiąc:</label>
                 </div>
-                <div class="mb-3">
-                  <label for="rok{{ p.id }}" class="form-label">Rok:</label>
-                  <input type="number" class="form-control" id="rok{{ p.id }}" name="rok" value="{{ ostatnie[p.id].year if p.id in ostatnie }}" required>
+                <div class="form-floating mb-3">
+                  <input type="number" class="form-control" id="rok{{ p.id }}" name="rok" placeholder="Rok" value="{{ ostatnie[p.id].year if p.id in ostatnie }}" required tabindex="2">
+                  <label for="rok{{ p.id }}">Rok:</label>
                 </div>
               </div>
               <div class="modal-footer">
-                <button type="submit" class="btn btn-primary">Pobierz</button>
-                <button type="submit" name="wyslij" value="1" class="btn btn-outline-secondary">Wyślij mailem</button>
+                <button type="submit" class="btn btn-primary" tabindex="3">Pobierz</button>
+                <button type="submit" name="wyslij" value="1" class="btn btn-outline-secondary" tabindex="4">Wyślij mailem</button>
               </div>
             </form>
           </div>
@@ -164,29 +164,29 @@
           </div>
           <div class="modal-body">
             <input type="hidden" name="edit_id" id="edit_id">
-            <div class="mb-3">
-              <label for="nowy_imie" class="form-label">Imię prowadzącego:</label>
-              <input type="text" class="form-control" id="nowy_imie" name="nowy_imie" required>
+            <div class="form-floating mb-3">
+              <input type="text" class="form-control" id="nowy_imie" name="nowy_imie" placeholder="Imię" required tabindex="1">
+              <label for="nowy_imie">Imię prowadzącego:</label>
             </div>
-            <div class="mb-3">
-              <label for="nowy_nazwisko" class="form-label">Nazwisko prowadzącego:</label>
-              <input type="text" class="form-control" id="nowy_nazwisko" name="nowy_nazwisko" required>
+            <div class="form-floating mb-3">
+              <input type="text" class="form-control" id="nowy_nazwisko" name="nowy_nazwisko" placeholder="Nazwisko" required tabindex="2">
+              <label for="nowy_nazwisko">Nazwisko prowadzącego:</label>
             </div>
-            <div class="mb-3">
-              <label for="nowy_umowa" class="form-label">Numer umowy:</label>
-              <input type="text" class="form-control" id="nowy_umowa" name="nowy_umowa" required>
+            <div class="form-floating mb-3">
+              <input type="text" class="form-control" id="nowy_umowa" name="nowy_umowa" placeholder="Numer umowy" required tabindex="3">
+              <label for="nowy_umowa">Numer umowy:</label>
             </div>
-            <div class="mb-3">
-              <label for="nowi_uczestnicy" class="form-label">Uczestnicy (po jednym na linię):</label>
-              <textarea class="form-control" id="nowi_uczestnicy" name="nowi_uczestnicy" rows="5" required></textarea>
+            <div class="form-floating mb-3">
+              <textarea class="form-control" id="nowi_uczestnicy" name="nowi_uczestnicy" placeholder="Uczestnicy" style="height: 7rem" required tabindex="4"></textarea>
+              <label for="nowi_uczestnicy">Uczestnicy (po jednym na linię):</label>
             </div>
-            <div class="mb-3">
-              <label for="nowy_podpis" class="form-label">Plik podpisu (.png lub .jpg):</label>
-              <input class="form-control" type="file" name="nowy_podpis" id="nowy_podpis" accept=".png,.jpg,.jpeg">
+            <div class="form-floating mb-3">
+              <input class="form-control" type="file" name="nowy_podpis" id="nowy_podpis" accept=".png,.jpg,.jpeg" tabindex="5">
+              <label for="nowy_podpis">Plik podpisu (.png lub .jpg):</label>
             </div>
           </div>
           <div class="modal-footer">
-            <button type="submit" class="btn btn-success">Zapisz prowadzącego</button>
+            <button type="submit" class="btn btn-success" tabindex="6">Zapisz prowadzącego</button>
           </div>
         </form>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -91,29 +91,29 @@
           </div>
           <div class="modal-body">
             <input type="hidden" name="edit_id" id="edit_id">
-            <div class="mb-3">
-              <label for="nowy_imie" class="form-label">Imię prowadzącego:</label>
-              <input type="text" class="form-control" id="nowy_imie" name="nowy_imie" required>
+            <div class="form-floating mb-3">
+              <input type="text" class="form-control" id="nowy_imie" name="nowy_imie" placeholder="Imię" required tabindex="1">
+              <label for="nowy_imie">Imię prowadzącego:</label>
             </div>
-            <div class="mb-3">
-              <label for="nowy_nazwisko" class="form-label">Nazwisko prowadzącego:</label>
-              <input type="text" class="form-control" id="nowy_nazwisko" name="nowy_nazwisko" required>
+            <div class="form-floating mb-3">
+              <input type="text" class="form-control" id="nowy_nazwisko" name="nowy_nazwisko" placeholder="Nazwisko" required tabindex="2">
+              <label for="nowy_nazwisko">Nazwisko prowadzącego:</label>
             </div>
-            <div class="mb-3">
-              <label for="nowy_umowa" class="form-label">Numer umowy:</label>
-              <input type="text" class="form-control" id="nowy_umowa" name="nowy_umowa" required>
+            <div class="form-floating mb-3">
+              <input type="text" class="form-control" id="nowy_umowa" name="nowy_umowa" placeholder="Numer umowy" required tabindex="3">
+              <label for="nowy_umowa">Numer umowy:</label>
             </div>
-            <div class="mb-3">
-              <label for="nowi_uczestnicy" class="form-label">Uczestnicy (po jednym na linię):</label>
-              <textarea class="form-control" id="nowi_uczestnicy" name="nowi_uczestnicy" rows="5" required></textarea>
+            <div class="form-floating mb-3">
+              <textarea class="form-control" id="nowi_uczestnicy" name="nowi_uczestnicy" placeholder="Uczestnicy" style="height: 7rem" required tabindex="4"></textarea>
+              <label for="nowi_uczestnicy">Uczestnicy (po jednym na linię):</label>
             </div>
-            <div class="mb-3">
-              <label for="nowy_podpis" class="form-label">Plik podpisu (.png lub .jpg):</label>
-              <input class="form-control" type="file" name="nowy_podpis" id="nowy_podpis" accept=".png,.jpg,.jpeg">
+            <div class="form-floating mb-3">
+              <input class="form-control" type="file" name="nowy_podpis" id="nowy_podpis" accept=".png,.jpg,.jpeg" tabindex="5">
+              <label for="nowy_podpis">Plik podpisu (.png lub .jpg):</label>
             </div>
           </div>
           <div class="modal-footer">
-            <button type="submit" class="btn btn-success">Zapisz prowadzącego</button>
+            <button type="submit" class="btn btn-success" tabindex="6">Zapisz prowadzącego</button>
           </div>
         </form>
       </div>

--- a/templates/login.html
+++ b/templates/login.html
@@ -24,13 +24,13 @@
     <h2 class="mb-4 text-center">Logowanie</h2>
     <form method="POST" action="/login">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <div class="mb-3">
-        <label for="login" class="form-label">Login:</label>
-        <input type="email" class="form-control" id="login" name="login" required>
+      <div class="form-floating mb-3">
+        <input type="email" class="form-control" id="login" name="login" placeholder="Login" required autocomplete="username" tabindex="1">
+        <label for="login">Login:</label>
       </div>
-      <div class="mb-3">
-        <label for="hasło" class="form-label">Hasło:</label>
-        <input type="password" class="form-control" id="hasło" name="hasło" required>
+      <div class="form-floating mb-3">
+        <input type="password" class="form-control" id="hasło" name="hasło" placeholder="Hasło" required autocomplete="current-password" tabindex="2">
+        <label for="hasło">Hasło:</label>
       </div>
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
@@ -40,11 +40,11 @@
         {% endif %}
       {% endwith %}
       <div class="d-grid mt-3">
-        <button type="submit" class="btn btn-primary">Zaloguj się</button>
+        <button type="submit" class="btn btn-primary" tabindex="3">Zaloguj się</button>
       </div>
     </form>
     <div class="text-center mt-3">
-      <a href="{{ url_for('routes.register') }}">Zarejestruj się</a>
+      <a href="{{ url_for('routes.register') }}" tabindex="4">Zarejestruj się</a>
     </div>
   </div>
 {% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -5,33 +5,33 @@
     <h2 class="mb-4 text-center">Rejestracja prowadzącego</h2>
     <form method="POST" enctype="multipart/form-data">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <div class="mb-3">
-        <label for="imie" class="form-label">Imię:</label>
-        <input type="text" class="form-control" id="imie" name="imie" required>
+      <div class="form-floating mb-3">
+        <input type="text" class="form-control" id="imie" name="imie" placeholder="Imię" required tabindex="1">
+        <label for="imie">Imię:</label>
       </div>
-      <div class="mb-3">
-        <label for="nazwisko" class="form-label">Nazwisko:</label>
-        <input type="text" class="form-control" id="nazwisko" name="nazwisko" required>
+      <div class="form-floating mb-3">
+        <input type="text" class="form-control" id="nazwisko" name="nazwisko" placeholder="Nazwisko" required tabindex="2">
+        <label for="nazwisko">Nazwisko:</label>
       </div>
-      <div class="mb-3">
-        <label for="numer_umowy" class="form-label">Numer umowy:</label>
-        <input type="text" class="form-control" id="numer_umowy" name="numer_umowy" required>
+      <div class="form-floating mb-3">
+        <input type="text" class="form-control" id="numer_umowy" name="numer_umowy" placeholder="Numer umowy" required tabindex="3">
+        <label for="numer_umowy">Numer umowy:</label>
       </div>
-      <div class="mb-3">
-        <label for="lista_uczestnikow" class="form-label">Lista uczestników (po jednym na linię):</label>
-        <textarea class="form-control" id="lista_uczestnikow" name="lista_uczestnikow" rows="5" required></textarea>
+      <div class="form-floating mb-3">
+        <textarea class="form-control" id="lista_uczestnikow" name="lista_uczestnikow" placeholder="Lista uczestników" style="height: 7rem" required tabindex="4"></textarea>
+        <label for="lista_uczestnikow">Lista uczestników (po jednym na linię):</label>
       </div>
-      <div class="mb-3">
-        <label for="login" class="form-label">Login (adres e-mail):</label>
-        <input type="email" class="form-control" id="login" name="login" required>
+      <div class="form-floating mb-3">
+        <input type="email" class="form-control" id="login" name="login" placeholder="Login" required autocomplete="username" tabindex="5">
+        <label for="login">Login (adres e-mail):</label>
       </div>
-      <div class="mb-3">
-        <label for="haslo" class="form-label">Hasło:</label>
-        <input type="password" class="form-control" id="haslo" name="haslo" required>
+      <div class="form-floating mb-3">
+        <input type="password" class="form-control" id="haslo" name="haslo" placeholder="Hasło" required autocomplete="new-password" tabindex="6">
+        <label for="haslo">Hasło:</label>
       </div>
-      <div class="mb-3">
-        <label for="podpis" class="form-label">Podpis (.png lub .jpg, opcjonalnie):</label>
-        <input type="file" class="form-control" id="podpis" name="podpis" accept=".png,.jpg,.jpeg">
+      <div class="form-floating mb-3">
+        <input type="file" class="form-control" id="podpis" name="podpis" accept=".png,.jpg,.jpeg" tabindex="7">
+        <label for="podpis">Podpis (.png lub .jpg, opcjonalnie):</label>
       </div>
       {% with messages = get_flashed_messages(with_categories=True) %}
         {% if messages %}
@@ -41,11 +41,11 @@
         {% endif %}
       {% endwith %}
       <div class="d-grid">
-        <button type="submit" class="btn btn-primary">Zarejestruj</button>
+        <button type="submit" class="btn btn-primary" tabindex="8">Zarejestruj</button>
       </div>
     </form>
     <div class="text-center mt-3">
-      <a href="{{ url_for('routes.login') }}">Powrót do logowania</a>
+      <a href="{{ url_for('routes.login') }}" tabindex="9">Powrót do logowania</a>
     </div>
   </div>
 {% endblock %}

--- a/templates/reset_form.html
+++ b/templates/reset_form.html
@@ -5,9 +5,9 @@
     <h2 class="mb-4 text-center">Ustaw nowe hasło</h2>
     <form method="POST">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <div class="mb-3">
-        <label for="password" class="form-label">Nowe hasło:</label>
-        <input type="password" class="form-control" id="password" name="password" required>
+      <div class="form-floating mb-3">
+        <input type="password" class="form-control" id="password" name="password" placeholder="Nowe hasło" required autocomplete="new-password" tabindex="1">
+        <label for="password">Nowe hasło:</label>
       </div>
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
@@ -17,7 +17,7 @@
         {% endif %}
       {% endwith %}
       <div class="d-grid">
-        <button type="submit" class="btn btn-primary">Zmień hasło</button>
+        <button type="submit" class="btn btn-primary" tabindex="2">Zmień hasło</button>
       </div>
     </form>
   </div>

--- a/templates/reset_request.html
+++ b/templates/reset_request.html
@@ -5,9 +5,9 @@
     <h2 class="mb-4 text-center">Reset hasła</h2>
     <form method="POST">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <div class="mb-3">
-        <label for="login" class="form-label">Adres e-mail:</label>
-        <input type="email" class="form-control" id="login" name="login" required>
+      <div class="form-floating mb-3">
+        <input type="email" class="form-control" id="login" name="login" placeholder="Adres e-mail" required autocomplete="username" tabindex="1">
+        <label for="login">Adres e-mail:</label>
       </div>
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
@@ -17,11 +17,11 @@
         {% endif %}
       {% endwith %}
       <div class="d-grid">
-        <button type="submit" class="btn btn-primary">Wyślij link</button>
+        <button type="submit" class="btn btn-primary" tabindex="2">Wyślij link</button>
       </div>
     </form>
     <div class="text-center mt-3">
-      <a href="{{ url_for('routes.login') }}">Powrót do logowania</a>
+      <a href="{{ url_for('routes.login') }}" tabindex="3">Powrót do logowania</a>
     </div>
   </div>
 {% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -11,37 +11,37 @@
   <form method="POST">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="row g-3">
-      <div class="col-md-6">
-        <label for="smtp_host" class="form-label">SMTP host:</label>
-        <input type="text" class="form-control" id="smtp_host" name="smtp_host" value="{{ values.smtp_host }}">
+      <div class="col-md-6 form-floating">
+        <input type="text" class="form-control" id="smtp_host" name="smtp_host" placeholder="SMTP host" value="{{ values.smtp_host }}" tabindex="1">
+        <label for="smtp_host">SMTP host:</label>
       </div>
-      <div class="col-md-6">
-        <label for="smtp_port" class="form-label">SMTP port:</label>
-        <input type="number" class="form-control" id="smtp_port" name="smtp_port" value="{{ values.smtp_port }}">
+      <div class="col-md-6 form-floating">
+        <input type="number" class="form-control" id="smtp_port" name="smtp_port" placeholder="SMTP port" value="{{ values.smtp_port }}" tabindex="2">
+        <label for="smtp_port">SMTP port:</label>
       </div>
-      <div class="col-md-6">
-        <label for="email_recipient" class="form-label">Email odbiorcy:</label>
-        <input type="email" class="form-control" id="email_recipient" name="email_recipient" value="{{ values.email_recipient }}">
+      <div class="col-md-6 form-floating">
+        <input type="email" class="form-control" id="email_recipient" name="email_recipient" placeholder="Email" value="{{ values.email_recipient }}" tabindex="3">
+        <label for="email_recipient">Email odbiorcy:</label>
       </div>
-      <div class="col-md-6">
-        <label for="max_signature_size" class="form-label">Limit rozmiaru podpisu (bajty):</label>
-        <input type="number" class="form-control" id="max_signature_size" name="max_signature_size" value="{{ values.max_signature_size }}">
+      <div class="col-md-6 form-floating">
+        <input type="number" class="form-control" id="max_signature_size" name="max_signature_size" placeholder="Limit" value="{{ values.max_signature_size }}" tabindex="4">
+        <label for="max_signature_size">Limit rozmiaru podpisu (bajty):</label>
       </div>
-      <div class="col-md-6">
-        <label for="email_sender_name" class="form-label">Nazwa nadawcy:</label>
-        <input type="text" class="form-control" id="email_sender_name" name="email_sender_name" value="{{ values.email_sender_name }}">
+      <div class="col-md-6 form-floating">
+        <input type="text" class="form-control" id="email_sender_name" name="email_sender_name" placeholder="Nazwa" value="{{ values.email_sender_name }}" tabindex="5">
+        <label for="email_sender_name">Nazwa nadawcy:</label>
       </div>
-      <div class="col-md-6">
-        <label for="email_login" class="form-label">Login SMTP:</label>
-        <input type="email" class="form-control" id="email_login" name="email_login" value="{{ values.email_login }}">
+      <div class="col-md-6 form-floating">
+        <input type="email" class="form-control" id="email_login" name="email_login" placeholder="Login" value="{{ values.email_login }}" tabindex="6" autocomplete="username">
+        <label for="email_login">Login SMTP:</label>
       </div>
-      <div class="col-md-6">
-        <label for="email_password" class="form-label">Hasło SMTP:</label>
-        <input type="password" class="form-control" id="email_password" name="email_password" value="{{ values.email_password }}">
+      <div class="col-md-6 form-floating">
+        <input type="password" class="form-control" id="email_password" name="email_password" placeholder="Hasło" value="{{ values.email_password }}" tabindex="7" autocomplete="current-password">
+        <label for="email_password">Hasło SMTP:</label>
       </div>
-      <div class="col-12">
-        <label for="email_footer" class="form-label">Stopka e-mail:</label>
-        <textarea class="form-control" id="email_footer" name="email_footer" rows="2">{{ values.email_footer }}</textarea>
+      <div class="col-12 form-floating">
+        <textarea class="form-control" id="email_footer" name="email_footer" placeholder="Stopka" style="height: 4rem" tabindex="8">{{ values.email_footer }}</textarea>
+        <label for="email_footer">Stopka e-mail:</label>
       </div>
     </div>
 
@@ -64,70 +64,70 @@
     </ul>
     <div class="tab-content border border-top-0 p-3" id="mailTabsContent">
       <div class="tab-pane fade show active" id="list" role="tabpanel">
-        <div class="mb-3">
-          <label for="email_list_subject" class="form-label">Temat:</label>
-          <input type="text" class="form-control" id="email_list_subject" name="email_list_subject" value="{{ values.email_list_subject }}">
+        <div class="form-floating mb-3">
+          <input type="text" class="form-control" id="email_list_subject" name="email_list_subject" placeholder="Temat" value="{{ values.email_list_subject }}" tabindex="9">
+          <label for="email_list_subject">Temat:</label>
         </div>
-        <div class="mb-3">
-          <label for="email_list_body" class="form-label">Treść:</label>
-          <textarea class="form-control" id="email_list_body" name="email_list_body" rows="2">{{ values.email_list_body }}</textarea>
+        <div class="form-floating mb-3">
+          <textarea class="form-control" id="email_list_body" name="email_list_body" placeholder="Treść" style="height: 4rem" tabindex="10">{{ values.email_list_body }}</textarea>
+          <label for="email_list_body">Treść:</label>
         </div>
       </div>
       <div class="tab-pane fade" id="report" role="tabpanel">
-        <div class="mb-3">
-          <label for="email_report_subject" class="form-label">Temat:</label>
-          <input type="text" class="form-control" id="email_report_subject" name="email_report_subject" value="{{ values.email_report_subject }}">
+        <div class="form-floating mb-3">
+          <input type="text" class="form-control" id="email_report_subject" name="email_report_subject" placeholder="Temat" value="{{ values.email_report_subject }}" tabindex="11">
+          <label for="email_report_subject">Temat:</label>
         </div>
-        <div class="mb-3">
-          <label for="email_report_body" class="form-label">Treść:</label>
-          <textarea class="form-control" id="email_report_body" name="email_report_body" rows="2">{{ values.email_report_body }}</textarea>
+        <div class="form-floating mb-3">
+          <textarea class="form-control" id="email_report_body" name="email_report_body" placeholder="Treść" style="height: 4rem" tabindex="12">{{ values.email_report_body }}</textarea>
+          <label for="email_report_body">Treść:</label>
         </div>
       </div>
       <div class="tab-pane fade" id="registration" role="tabpanel">
-        <div class="mb-3">
-          <label for="registration_email_subject" class="form-label">Temat:</label>
-          <input type="text" class="form-control" id="registration_email_subject" name="registration_email_subject" value="{{ values.registration_email_subject }}">
+        <div class="form-floating mb-3">
+          <input type="text" class="form-control" id="registration_email_subject" name="registration_email_subject" placeholder="Temat" value="{{ values.registration_email_subject }}" tabindex="13">
+          <label for="registration_email_subject">Temat:</label>
         </div>
-        <div class="mb-3">
-          <label for="registration_email_body" class="form-label">Treść:</label>
-          <textarea class="form-control" id="registration_email_body" name="registration_email_body" rows="2">{{ values.registration_email_body }}</textarea>
+        <div class="form-floating mb-3">
+          <textarea class="form-control" id="registration_email_body" name="registration_email_body" placeholder="Treść" style="height: 4rem" tabindex="14">{{ values.registration_email_body }}</textarea>
+          <label for="registration_email_body">Treść:</label>
         </div>
       </div>
       <div class="tab-pane fade" id="activation" role="tabpanel">
-        <div class="mb-3">
-          <label for="reg_email_subject" class="form-label">Temat:</label>
-          <input type="text" class="form-control" id="reg_email_subject" name="reg_email_subject" value="{{ values.reg_email_subject }}">
+        <div class="form-floating mb-3">
+          <input type="text" class="form-control" id="reg_email_subject" name="reg_email_subject" placeholder="Temat" value="{{ values.reg_email_subject }}" tabindex="15">
+          <label for="reg_email_subject">Temat:</label>
         </div>
-        <div class="mb-3">
-          <label for="reg_email_body" class="form-label">Treść:</label>
-          <textarea class="form-control" id="reg_email_body" name="reg_email_body" rows="2">{{ values.reg_email_body }}</textarea>
+        <div class="form-floating mb-3">
+          <textarea class="form-control" id="reg_email_body" name="reg_email_body" placeholder="Treść" style="height: 4rem" tabindex="16">{{ values.reg_email_body }}</textarea>
+          <label for="reg_email_body">Treść:</label>
         </div>
       </div>
       <div class="tab-pane fade" id="reset" role="tabpanel">
-        <div class="mb-3">
-          <label for="reset_email_subject" class="form-label">Temat:</label>
-          <input type="text" class="form-control" id="reset_email_subject" name="reset_email_subject" value="{{ values.reset_email_subject }}">
+        <div class="form-floating mb-3">
+          <input type="text" class="form-control" id="reset_email_subject" name="reset_email_subject" placeholder="Temat" value="{{ values.reset_email_subject }}" tabindex="17">
+          <label for="reset_email_subject">Temat:</label>
         </div>
-        <div class="mb-3">
-          <label for="reset_email_body" class="form-label">Treść:</label>
-          <textarea class="form-control" id="reset_email_body" name="reset_email_body" rows="2">{{ values.reset_email_body }}</textarea>
+        <div class="form-floating mb-3">
+          <textarea class="form-control" id="reset_email_body" name="reset_email_body" placeholder="Treść" style="height: 4rem" tabindex="18">{{ values.reset_email_body }}</textarea>
+          <label for="reset_email_body">Treść:</label>
         </div>
       </div>
     </div>
     <hr class="my-4">
     <h5>Dane administratora</h5>
     <div class="row g-3">
-      <div class="col-md-6">
-        <label for="admin_login" class="form-label">Login admina:</label>
-        <input type="email" class="form-control" id="admin_login" name="admin_login" value="{{ admin_login }}">
+      <div class="col-md-6 form-floating">
+        <input type="email" class="form-control" id="admin_login" name="admin_login" placeholder="Login" value="{{ admin_login }}" autocomplete="username" tabindex="19">
+        <label for="admin_login">Login admina:</label>
       </div>
-      <div class="col-md-6">
-        <label for="admin_password" class="form-label">Nowe hasło:</label>
-        <input type="password" class="form-control" id="admin_password" name="admin_password">
+      <div class="col-md-6 form-floating">
+        <input type="password" class="form-control" id="admin_password" name="admin_password" placeholder="Hasło" autocomplete="new-password" tabindex="20">
+        <label for="admin_password">Nowe hasło:</label>
       </div>
     </div>
     <div class="mt-4">
-      <button type="submit" class="btn btn-primary">Zapisz</button>
+      <button type="submit" class="btn btn-primary" tabindex="21">Zapisz</button>
     </div>
   </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- switch login and register forms to `form-floating` style
- update admin modals and settings page with floating fields
- add `autocomplete` and `tabindex` attributes for better accessibility

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844c30bc358832abd647db9b110e8d7