### PR TITLE
Improve accessibility of icon-only buttons

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -73,13 +73,18 @@
         <td class="text-nowrap">
           <button class="btn btn-sm" onclick="edytujProwadzacego({{ p.id }}, '{{ p.imie }}', '{{ p.nazwisko }}', '{{ p.numer_umowy }}', [{% for u in p.uczestnicy %}'{{ u.imie_nazwisko }}'{% if not loop.last %}, {% endif %}{% endfor %}])" aria-label="Edytuj prowadzącego">
             <i class="bi bi-pencil"></i>
+            <span class="visually-hidden">Edytuj prowadzącego</span>
           </button>
           <form action="{{ url_for('routes.usun_prowadzacego', id=p.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć?')">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń prowadzącego"><i class="bi bi-trash"></i></button>
+            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń prowadzącego">
+              <i class="bi bi-trash"></i>
+              <span class="visually-hidden">Usuń prowadzącego</span>
+            </button>
           </form>
           <button class="btn btn-sm text-primary" data-bs-toggle="modal" data-bs-target="#raportModal{{ p.id }}" aria-label="Raport miesięczny">
             <i class="bi bi-file-earmark-text"></i>
+            <span class="visually-hidden">Raport miesięczny</span>
           </button>
         </td>
       </tr>
@@ -145,7 +150,10 @@
         <td>
           <form action="{{ url_for('routes.usun_zajecie', id=z.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć zajęcia?')">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń zajęcia"><i class="bi bi-trash"></i></button>
+            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń zajęcia">
+              <i class="bi bi-trash"></i>
+              <span class="visually-hidden">Usuń zajęcia</span>
+            </button>
           </form>
         </td>
       </tr>

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,6 +43,7 @@
       </div>
       <button type="button" class="btn btn-outline-success ms-3" style="white-space: nowrap;" data-bs-toggle="modal" data-bs-target="#dodajModal" aria-label="Dodaj prowadzącego">
         <i class="bi bi-person-plus"></i>
+        <span class="visually-hidden">Dodaj prowadzącego</span>
       </button>
     </div>
     {% else %}

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -68,10 +68,16 @@
           </ul>
         </td>
         <td class="text-nowrap">
-          <a href="{{ url_for('routes.pobierz_zajecie', id=z.id) }}" class="btn btn-sm text-primary" aria-label="Pobierz dokument"><i class="bi bi-download"></i></a>
+          <a href="{{ url_for('routes.pobierz_zajecie', id=z.id) }}" class="btn btn-sm text-primary" aria-label="Pobierz dokument">
+            <i class="bi bi-download"></i>
+            <span class="visually-hidden">Pobierz dokument</span>
+          </a>
           <form action="{{ url_for('routes.usun_moje_zajecie', id=z.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Usunąć zajęcia?')">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń zajęcia"><i class="bi bi-trash"></i></button>
+            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń zajęcia">
+              <i class="bi bi-trash"></i>
+              <span class="visually-hidden">Usuń zajęcia</span>
+            </button>
           </form>
         </td>
       </tr>


### PR DESCRIPTION
## Summary
- add hidden text to edit, delete and download buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844c4a22d44832abd130cc35bc2551c