### PR TITLE
Improve accessibility of flash message blocks

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -33,13 +33,15 @@
 
   <h2 class="mb-4">Lista prowadzących</h2>
 
-  {% with messages = get_flashed_messages(with_categories=True) %}
-    {% if messages %}
-      {% for category, message in messages %}
-        <div class="alert alert-{{ category }} mt-3" role="alert">{{ message }}</div>
-      {% endfor %}
-    {% endif %}
-  {% endwith %}
+  <div aria-live="polite" role="status">
+    {% with messages = get_flashed_messages(with_categories=True) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="alert alert-{{ category }} mt-3" role="alert">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+  </div>
 
   <table class="table table-striped table-bordered align-middle">
     <thead class="table-dark">

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,13 +28,15 @@
 {% endif %}
   <h1 class="mb-4 text-center">Lista obecności – ShareOKO</h1>
 
-  {% with messages = get_flashed_messages(with_categories=True) %}
-    {% if messages %}
-      {% for category, message in messages %}
-        <div class="alert alert-{{ category }} mt-3" role="alert">{{ message }}</div>
-      {% endfor %}
-    {% endif %}
-  {% endwith %}
+  <div aria-live="polite" role="status">
+    {% with messages = get_flashed_messages(with_categories=True) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="alert alert-{{ category }} mt-3" role="alert">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+  </div>
 
   <form method="POST" enctype="multipart/form-data" aria-label="Formularz listy obecności">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/templates/login.html
+++ b/templates/login.html
@@ -32,13 +32,15 @@
         <input type="password" class="form-control" id="hasło" name="hasło" placeholder="Hasło" required autocomplete="current-password" tabindex="2">
         <label for="hasło">Hasło:</label>
       </div>
-      {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-          {% for category, message in messages %}
-            <div class="alert alert-{{ category }} mt-3" role="alert">{{ message }}</div>
-          {% endfor %}
-        {% endif %}
-      {% endwith %}
+      <div aria-live="polite" role="status">
+        {% with messages = get_flashed_messages(with_categories=true) %}
+          {% if messages %}
+            {% for category, message in messages %}
+              <div class="alert alert-{{ category }} mt-3" role="alert">{{ message }}</div>
+            {% endfor %}
+          {% endif %}
+        {% endwith %}
+      </div>
       <div class="d-grid mt-3">
         <button type="submit" class="btn btn-primary" tabindex="3">Zaloguj się</button>
       </div>

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -1,13 +1,15 @@
 {% extends 'base.html' %}
 {% block title %}Panel prowadzącego{% endblock %}
 {% block content %}
-  {% with messages = get_flashed_messages(with_categories=True) %}
-    {% if messages %}
-      {% for category, message in messages %}
-        <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
-      {% endfor %}
-    {% endif %}
-  {% endwith %}
+  <div aria-live="polite" role="status">
+    {% with messages = get_flashed_messages(with_categories=True) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+  </div>
 
   <h2 class="mb-4">Moje dane</h2>
   <form method="POST" action="{{ url_for('routes.panel_update_profile') }}" enctype="multipart/form-data" class="mb-5">

--- a/templates/register.html
+++ b/templates/register.html
@@ -33,13 +33,15 @@
         <input type="file" class="form-control" id="podpis" name="podpis" accept=".png,.jpg,.jpeg" tabindex="7">
         <label for="podpis">Podpis (.png lub .jpg, opcjonalnie):</label>
       </div>
-      {% with messages = get_flashed_messages(with_categories=True) %}
-        {% if messages %}
-          {% for category, message in messages %}
-            <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
-          {% endfor %}
-        {% endif %}
-      {% endwith %}
+      <div aria-live="polite" role="status">
+        {% with messages = get_flashed_messages(with_categories=True) %}
+          {% if messages %}
+            {% for category, message in messages %}
+              <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
+            {% endfor %}
+          {% endif %}
+        {% endwith %}
+      </div>
       <div class="d-grid">
         <button type="submit" class="btn btn-primary" tabindex="8">Zarejestruj</button>
       </div>

--- a/templates/reset_form.html
+++ b/templates/reset_form.html
@@ -9,13 +9,15 @@
         <input type="password" class="form-control" id="password" name="password" placeholder="Nowe hasło" required autocomplete="new-password" tabindex="1">
         <label for="password">Nowe hasło:</label>
       </div>
-      {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-          {% for category, message in messages %}
-            <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
-          {% endfor %}
-        {% endif %}
-      {% endwith %}
+      <div aria-live="polite" role="status">
+        {% with messages = get_flashed_messages(with_categories=true) %}
+          {% if messages %}
+            {% for category, message in messages %}
+              <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
+            {% endfor %}
+          {% endif %}
+        {% endwith %}
+      </div>
       <div class="d-grid">
         <button type="submit" class="btn btn-primary" tabindex="2">Zmień hasło</button>
       </div>

--- a/templates/reset_request.html
+++ b/templates/reset_request.html
@@ -9,13 +9,15 @@
         <input type="email" class="form-control" id="login" name="login" placeholder="Adres e-mail" required autocomplete="username" tabindex="1">
         <label for="login">Adres e-mail:</label>
       </div>
-      {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-          {% for category, message in messages %}
-            <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
-          {% endfor %}
-        {% endif %}
-      {% endwith %}
+      <div aria-live="polite" role="status">
+        {% with messages = get_flashed_messages(with_categories=true) %}
+          {% if messages %}
+            {% for category, message in messages %}
+              <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
+            {% endfor %}
+          {% endif %}
+        {% endwith %}
+      </div>
       <div class="d-grid">
         <button type="submit" class="btn btn-primary" tabindex="2">Wyślij link</button>
       </div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,13 +1,15 @@
 {% extends 'base.html' %}
 {% block title %}Ustawienia{% endblock %}
 {% block content %}
-  {% with messages = get_flashed_messages(with_categories=True) %}
-    {% if messages %}
-      {% for category, message in messages %}
-        <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
-      {% endfor %}
-    {% endif %}
-  {% endwith %}
+  <div aria-live="polite" role="status">
+    {% with messages = get_flashed_messages(with_categories=True) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+  </div>
   <form method="POST">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="row g-3">


### PR DESCRIPTION
## Summary
- wrap flashed message blocks in containers with `aria-live="polite"` and `role="status"`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844cbbb6440832aa3d8d4c6f57fec9c