### PR TITLE
Allow setting dev server host

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Copy `.env.example` to `.env` and adjust the values, or export them manually:
 - `ADMIN_LOGIN` – e-mail address of the administrator account created by `init_db.py`.
 - `ADMIN_PASSWORD` – password for the administrator account.
 - `DATABASE_URL` – optional database URI (default `sqlite:///obecnosc.db`).
+- `FLASK_HOST` – optional host for development (default `127.0.0.1`).
 - Mail configuration used when sending attendance lists and reports:
   - `EMAIL_RECIPIENT` – address of the coordinator receiving emails.
   - `SMTP_HOST` – SMTP server hostname.
@@ -25,6 +26,10 @@ Copy `.env.example` to `.env` and adjust the values, or export them manually:
   - `REGISTRATION_EMAIL_SUBJECT` / `REGISTRATION_EMAIL_BODY` – templates for registration notifications (`{name}`, `{login}`, `{link}`).
   - `REG_EMAIL_SUBJECT` / `REG_EMAIL_BODY` – templates for the account activation e-mail.
   - `RESET_EMAIL_SUBJECT` / `RESET_EMAIL_BODY` – templates for password reset messages (`{link}`).
+
+The development server started with `python app.py` listens on
+`127.0.0.1` by default. Set the `FLASK_HOST` variable if you need a
+different address.
 
 The placeholders shown above are substituted automatically when the e-mails are
 sent. For example, `{date}` is replaced with the list or report date and `{link}`

--- a/app.py
+++ b/app.py
@@ -56,4 +56,5 @@ def load_user(user_id):
 
 if __name__ == "__main__":
     app = create_app()
-    app.run(host="0.0.0.0", port=5000)
+    host = os.getenv("FLASK_HOST", "127.0.0.1")
+    app.run(host=host, port=5000)


### PR DESCRIPTION
## Summary
- make the development server host configurable via `FLASK_HOST`
- document the new `FLASK_HOST` variable and default value

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844cc99b808832ab3e253f840555725