### PR TITLE
Add edit routes for attendance

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -149,7 +149,15 @@
             {% endfor %}
           </ul>
         </td>
-        <td>
+        <td class="text-nowrap">
+          <a href="{{ url_for('routes.edytuj_zajecie', id=z.id) }}" class="btn btn-sm" aria-label="Edytuj zajęcia">
+            <i class="bi bi-pencil"></i>
+            <span class="visually-hidden">Edytuj zajęcia</span>
+          </a>
+          <a href="{{ url_for('routes.pobierz_zajecie_admin', id=z.id) }}" class="btn btn-sm text-primary" aria-label="Pobierz dokument">
+            <i class="bi bi-download"></i>
+            <span class="visually-hidden">Pobierz dokument</span>
+          </a>
           <form action="{{ url_for('routes.usun_zajecie', id=z.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć zajęcia?')">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń zajęcia">

--- a/templates/edit_zajecie.html
+++ b/templates/edit_zajecie.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+{% block title %}Edytuj zajęcia{% endblock %}
+{% block content %}
+  <h2 class="mb-4">Edytuj zajęcia</h2>
+  <form method="POST">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div class="mb-3">
+      <label for="data" class="form-label">Data zajęć:</label>
+      <input type="date" class="form-control" id="data" name="data" value="{{ zajecie.data.strftime('%Y-%m-%d') }}" required>
+    </div>
+    <div class="mb-3">
+      <label for="czas" class="form-label">Czas trwania zajęć:</label>
+      <input type="text" class="form-control" id="czas" name="czas" value="{{ czas }}" required>
+    </div>
+    <fieldset class="mb-3">
+      <legend>Lista uczestników</legend>
+      {% for u in uczestnicy %}
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="obecny" id="u{{ u.id }}" value="{{ u.id }}" {% if u.id in obecni_ids %}checked{% endif %}>
+          <label class="form-check-label" for="u{{ u.id }}">{{ u.imie_nazwisko }}</label>
+        </div>
+      {% endfor %}
+    </fieldset>
+    <button type="submit" class="btn btn-primary">Zapisz zmiany</button>
+    <a href="{{ back_url }}" class="btn btn-secondary ms-2">Anuluj</a>
+  </form>
+{% endblock %}

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -70,6 +70,10 @@
           </ul>
         </td>
         <td class="text-nowrap">
+          <a href="{{ url_for('routes.panel_edytuj_zajecie', id=z.id) }}" class="btn btn-sm" aria-label="Edytuj zajęcia">
+            <i class="bi bi-pencil"></i>
+            <span class="visually-hidden">Edytuj zajęcia</span>
+          </a>
           <a href="{{ url_for('routes.pobierz_zajecie', id=z.id) }}" class="btn btn-sm text-primary" aria-label="Pobierz dokument">
             <i class="bi bi-download"></i>
             <span class="visually-hidden">Pobierz dokument</span>


### PR DESCRIPTION
## Summary
- enable admins and trainers to edit stored class records
- allow admins to download attendance documents
- update admin and trainer tables with edit and download buttons
- create shared template for editing a class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68457da69dd8832aa79ed4ce4a95b1b6