### PR TITLE
Add collapsible lists

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -66,11 +66,17 @@
           {% endif %}
         </td>
         <td>
-          <ul class="mb-0">
-            {% for u in p.uczestnicy %}
-              <li>{{ u.imie_nazwisko }}</li>
-            {% endfor %}
-          </ul>
+          <button type="button" class="btn btn-sm" data-bs-toggle="collapse" data-bs-target="#list{{ p.id }}" aria-expanded="false" aria-controls="list{{ p.id }}">
+            <i class="bi bi-caret-right"></i>
+            <span class="visually-hidden">Pokaż listę</span>
+          </button>
+          <div class="collapse" id="list{{ p.id }}">
+            <ul class="mb-0 mt-2">
+              {% for u in p.uczestnicy %}
+                <li>{{ u.imie_nazwisko }}</li>
+              {% endfor %}
+            </ul>
+          </div>
         </td>
         <td class="text-nowrap">
           <button class="btn btn-sm" onclick="edytujProwadzacego({{ p.id }}, '{{ p.imie }}', '{{ p.nazwisko }}', '{{ p.numer_umowy }}', [{% for u in p.uczestnicy %}'{{ u.imie_nazwisko }}'{% if not loop.last %}, {% endif %}{% endfor %}])" aria-label="Edytuj prowadzącego">
@@ -142,13 +148,19 @@
         <td>{{ z.data }}</td>
         <td>{{ z.czas_trwania }}</td>
         <td>{{ z.prowadzacy.imie }} {{ z.prowadzacy.nazwisko }}</td>
-        <td>
-          <ul class="mb-0">
-            {% for o in z.obecni %}
-              <li>{{ o.imie_nazwisko }}</li>
-            {% endfor %}
-          </ul>
-        </td>
+          <td>
+            <button type="button" class="btn btn-sm" data-bs-toggle="collapse" data-bs-target="#list{{ z.id }}" aria-expanded="false" aria-controls="list{{ z.id }}">
+              <i class="bi bi-caret-right"></i>
+              <span class="visually-hidden">Pokaż listę</span>
+            </button>
+            <div class="collapse" id="list{{ z.id }}">
+              <ul class="mb-0 mt-2">
+                {% for o in z.obecni %}
+                  <li>{{ o.imie_nazwisko }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+          </td>
         <td class="text-nowrap">
           <a href="{{ url_for('routes.edytuj_zajecie', id=z.id) }}" class="btn btn-sm" aria-label="Edytuj zajęcia">
             <i class="bi bi-pencil"></i>

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -63,11 +63,17 @@
         <td>{{ z.data.date() }}</td>
         <td>{{ z.czas_trwania }}</td>
         <td>
-          <ul class="mb-0">
-            {% for o in z.obecni %}
-              <li>{{ o.imie_nazwisko }}</li>
-            {% endfor %}
-          </ul>
+          <button type="button" class="btn btn-sm" data-bs-toggle="collapse" data-bs-target="#list{{ z.id }}" aria-expanded="false" aria-controls="list{{ z.id }}">
+            <i class="bi bi-caret-right"></i>
+            <span class="visually-hidden">Pokaż listę</span>
+          </button>
+          <div class="collapse" id="list{{ z.id }}">
+            <ul class="mb-0 mt-2">
+              {% for o in z.obecni %}
+                <li>{{ o.imie_nazwisko }}</li>
+              {% endfor %}
+            </ul>
+          </div>
         </td>
         <td class="text-nowrap">
           <a href="{{ url_for('routes.panel_edytuj_zajecie', id=z.id) }}" class="btn btn-sm" aria-label="Edytuj zajęcia">


### PR DESCRIPTION
## Summary
- make participant lists expandable with Bootstrap collapse

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68457ecb26a8832a9e36bcd68a0973d6