### PR TITLE
Fix login layout

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -16,12 +16,14 @@
         <img src="https://vestmedia.pl/wp-content/uploads/2024/12/Vest-Media-5.png" alt="Vest Media" height="40">
       </a>
       <div class="d-flex gap-2">
+        {% if show_nav_buttons|default(True) %}
         <a href="{{ url_for('routes.index') }}" class="btn btn-outline-light">Powrót</a>
         {% if is_admin %}
         <a href="{{ url_for('routes.admin_dashboard') }}" class="btn btn-outline-light">Panel administratora</a>
         <a href="{{ url_for('routes.admin_settings') }}" class="btn btn-outline-light" aria-label="Ustawienia"><i class="bi bi-gear"></i></a>
         {% elif current_user.is_authenticated %}
         <a href="{{ url_for('routes.panel') }}" class="btn btn-outline-light">{% if current_user.role == 'prowadzacy' %}Panel prowadzącego{% else %}Panel{% endif %}</a>
+        {% endif %}
         {% endif %}
         {% if current_user.is_authenticated %}
         <a href="{{ url_for('routes.logout') }}" class="btn btn-outline-danger">Wyloguj</a>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,14 +1,8 @@
 {% extends 'base.html' %}
+{% set show_nav_buttons = False %}
 {% block title %}Logowanie{% endblock %}
 {% block head_extra %}
   <style>
-    body {
-      background-color: #f4f4f8;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      height: 100vh;
-    }
     .login-box {
       max-width: 400px;
       background: white;
@@ -19,7 +13,8 @@
   </style>
 {% endblock %}
 {% block content %}
-  <div class="login-box mx-auto">
+  <div class="d-flex justify-content-center align-items-center min-vh-100">
+    <div class="login-box">
     <h2 class="mb-4 text-center">Logowanie</h2>
     <form method="POST" action="/login">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -48,4 +43,5 @@
       <a href="{{ url_for('routes.register') }}" tabindex="4">Zarejestruj się</a>
     </div>
   </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove body styling on the login page
- center login box using bootstrap utilities
- add optional navigation toggle in base template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845880a6178832ab0a82b15e50060fb