### PR TITLE
Improve collapsed row display

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -135,6 +135,7 @@
   <table class="table table-striped table-hover">
     <thead class="table-secondary">
       <tr>
+        <th></th>
         <th>Data</th>
         <th>Czas trwania</th>
         <th>Prowadzący</th>
@@ -145,22 +146,16 @@
     <tbody>
       {% for z in zajecia %}
       <tr>
+        <td class="text-center">
+          <button type="button" class="btn btn-sm" data-bs-toggle="collapse" data-bs-target="#row{{ z.id }}" aria-expanded="false" aria-controls="row{{ z.id }}">
+            <i class="bi bi-caret-right"></i>
+            <span class="visually-hidden">Pokaż listę</span>
+          </button>
+        </td>
         <td>{{ z.data }}</td>
         <td>{{ z.czas_trwania }}</td>
         <td>{{ z.prowadzacy.imie }} {{ z.prowadzacy.nazwisko }}</td>
-          <td>
-            <button type="button" class="btn btn-sm" data-bs-toggle="collapse" data-bs-target="#list{{ z.id }}" aria-expanded="false" aria-controls="list{{ z.id }}">
-              <i class="bi bi-caret-right"></i>
-              <span class="visually-hidden">Pokaż listę</span>
-            </button>
-            <div class="collapse" id="list{{ z.id }}">
-              <ul class="mb-0 mt-2">
-                {% for o in z.obecni %}
-                  <li>{{ o.imie_nazwisko }}</li>
-                {% endfor %}
-              </ul>
-            </div>
-          </td>
+        <td>{{ z.obecni|length }}</td>
         <td class="text-nowrap">
           <a href="{{ url_for('routes.edytuj_zajecie', id=z.id) }}" class="btn btn-sm" aria-label="Edytuj zajęcia">
             <i class="bi bi-pencil"></i>
@@ -177,6 +172,15 @@
               <span class="visually-hidden">Usuń zajęcia</span>
             </button>
           </form>
+        </td>
+      </tr>
+      <tr class="collapse" id="row{{ z.id }}">
+        <td colspan="6">
+          <ul class="mb-0 mt-2">
+            {% for o in z.obecni %}
+              <li>{{ o.imie_nazwisko }}</li>
+            {% endfor %}
+          </ul>
         </td>
       </tr>
       {% endfor %}

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -51,6 +51,7 @@
   <table class="table table-striped table-hover">
     <thead class="table-secondary">
       <tr>
+        <th></th>
         <th>Data</th>
         <th>Czas</th>
         <th>Obecni</th>
@@ -60,21 +61,15 @@
     <tbody>
       {% for z in zajecia %}
       <tr>
-        <td>{{ z.data.date() }}</td>
-        <td>{{ z.czas_trwania }}</td>
-        <td>
-          <button type="button" class="btn btn-sm" data-bs-toggle="collapse" data-bs-target="#list{{ z.id }}" aria-expanded="false" aria-controls="list{{ z.id }}">
+        <td class="text-center">
+          <button type="button" class="btn btn-sm" data-bs-toggle="collapse" data-bs-target="#row{{ z.id }}" aria-expanded="false" aria-controls="row{{ z.id }}">
             <i class="bi bi-caret-right"></i>
             <span class="visually-hidden">Pokaż listę</span>
           </button>
-          <div class="collapse" id="list{{ z.id }}">
-            <ul class="mb-0 mt-2">
-              {% for o in z.obecni %}
-                <li>{{ o.imie_nazwisko }}</li>
-              {% endfor %}
-            </ul>
-          </div>
         </td>
+        <td>{{ z.data.date() }}</td>
+        <td>{{ z.czas_trwania }}</td>
+        <td>{{ z.obecni|length }}</td>
         <td class="text-nowrap">
           <a href="{{ url_for('routes.panel_edytuj_zajecie', id=z.id) }}" class="btn btn-sm" aria-label="Edytuj zajęcia">
             <i class="bi bi-pencil"></i>
@@ -91,6 +86,15 @@
               <span class="visually-hidden">Usuń zajęcia</span>
             </button>
           </form>
+        </td>
+      </tr>
+      <tr class="collapse" id="row{{ z.id }}">
+        <td colspan="5">
+          <ul class="mb-0 mt-2">
+            {% for o in z.obecni %}
+              <li>{{ o.imie_nazwisko }}</li>
+            {% endfor %}
+          </ul>
         </td>
       </tr>
       {% endfor %}


### PR DESCRIPTION
## Summary
- toggle presence lists in tables using row collapse
- add arrow column so table layouts stay fixed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845939e8d64832a935a0b4b1aa3a8ad