### PR TITLE
Add signature validation helper

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,7 @@
+import io
+from werkzeug.datastructures import FileStorage
+
+import utils
 from utils import is_valid_email
 
 
@@ -5,3 +9,27 @@ def test_is_valid_email():
     assert is_valid_email('user@example.com')
     assert not is_valid_email('invalid')
     assert not is_valid_email('a@')
+
+
+def test_validate_signature_ok(monkeypatch):
+    monkeypatch.setattr(utils, 'SIGNATURE_MAX_SIZE', 10)
+    fs = FileStorage(io.BytesIO(b'x'), filename='sig.png', content_type='image/png')
+    name, error = utils.validate_signature(fs)
+    assert name == 'sig.png'
+    assert error is None
+
+
+def test_validate_signature_bad_extension(monkeypatch):
+    monkeypatch.setattr(utils, 'SIGNATURE_MAX_SIZE', 10)
+    fs = FileStorage(io.BytesIO(b'x'), filename='sig.txt', content_type='text/plain')
+    name, error = utils.validate_signature(fs)
+    assert name is None
+    assert error
+
+
+def test_validate_signature_too_big(monkeypatch):
+    monkeypatch.setattr(utils, 'SIGNATURE_MAX_SIZE', 1)
+    fs = FileStorage(io.BytesIO(b'ab'), filename='sig.png', content_type='image/png')
+    name, error = utils.validate_signature(fs)
+    assert name is None
+    assert error


### PR DESCRIPTION
## Summary
- add `utils.validate_signature` and new `SignatureValidationError`
- reuse validation helper in auth, admin and panel routes
- expand test suite for signature validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459abaf8e8832a989cf6ae7af4bace