### PR TITLE
Add signature image processing helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ The files `szablon.docx` (attendance template) and `rejestr.docx` (monthly repor
 Only PNG and JPG files are accepted when uploading signature images in the admin
 or trainer panels. Files with other extensions or MIME types will be rejected.
 Uploads larger than the value of `MAX_SIGNATURE_SIZE` (default 1 MB) will also be refused.
-If `REMOVE_SIGNATURE_BG` is set, the application removes white background from uploaded signatures and stores them as PNG files.
-The processing is handled by `utils.process_signature()` using the `Pillow`
-library. Installing the optional `rembg` package allows for more advanced
-background removal when the option is enabled.
+If `REMOVE_SIGNATURE_BG` is set, the application removes white background from
+uploaded signatures and stores them as PNG files. The helper
+`utils.process_signature(file)` performs this conversion and returns the saved
+filename using the `Pillow` library. Installing the optional `rembg` package
+allows for more advanced background removal when the option is enabled.
 
 ## Login format
 

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -201,10 +201,8 @@ def dodaj_prowadzacego():
             return redirect(url_for('routes.admin_dashboard'))
 
     if podpis and sanitized:
-        base = os.path.splitext(sanitized)[0]
-        orig_ext = sanitized.rsplit('.', 1)[-1].lower()
         try:
-            filename = process_signature(podpis.stream, f"{prow.id}_{base}", orig_ext)
+            filename = process_signature(podpis.stream)
         except Exception:
             flash('Nie udało się przetworzyć obrazu podpisu', 'danger')
             return redirect(url_for('routes.admin_dashboard'))

--- a/routes/panel.py
+++ b/routes/panel.py
@@ -55,10 +55,8 @@ def panel_update_profile():
             return redirect(url_for('routes.panel'))
 
     if podpis and sanitized:
-        base = os.path.splitext(sanitized)[0]
-        orig_ext = sanitized.rsplit('.', 1)[-1].lower()
         try:
-            filename = process_signature(podpis.stream, f"{prow.id}_{base}", orig_ext)
+            filename = process_signature(podpis.stream)
         except Exception:
             flash('Nie udało się przetworzyć obrazu podpisu', 'danger')
             return redirect(url_for('routes.panel'))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import io
 from werkzeug.datastructures import FileStorage
+from PIL import Image
 
 import utils
 from utils import is_valid_email
@@ -33,3 +34,18 @@ def test_validate_signature_too_big(monkeypatch):
     name, error = utils.validate_signature(fs)
     assert name is None
     assert error
+
+
+def test_process_signature(monkeypatch, tmp_path):
+    monkeypatch.setattr(utils, 'REMOVE_SIGNATURE_BG', False)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / 'static').mkdir()
+    img = Image.new('RGB', (1, 1), (255, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format='PNG')
+    buf.seek(0)
+    filename = utils.process_signature(buf)
+    saved = tmp_path / 'static' / filename
+    assert saved.exists()
+    out = Image.open(saved)
+    assert out.format == 'PNG'

--- a/utils.py
+++ b/utils.py
@@ -9,6 +9,7 @@ import logging
 from email.message import EmailMessage
 import re
 from werkzeug.utils import secure_filename
+import uuid
 from PIL import Image
 try:
     from rembg import remove as rembg_remove  # type: ignore
@@ -227,20 +228,15 @@ def send_plain_email(
         raise
 
 
-def process_signature(file, dest_base, original_ext):
-    """Process an uploaded signature image and save it to ``static/``.
+def process_signature(file):
+    """Process an uploaded signature image and save it to ``static/`` as PNG.
 
-    ``file`` should be a file-like object positioned at the start. ``dest_base``
-    is used as the filename without extension while ``original_ext`` is the
-    extension of the uploaded file. If ``REMOVE_SIGNATURE_BG`` is enabled the
-    output is always a PNG with white background removed using ``rembg`` when
-    available.
-
-    The function returns the final filename placed inside ``static/``.
+    ``file`` should be a file-like object positioned at the start. A random
+    filename is generated and returned. When ``REMOVE_SIGNATURE_BG`` is enabled,
+    white background is removed using ``rembg`` when available.
     """
 
-    ext = "png" if REMOVE_SIGNATURE_BG else original_ext.lower()
-    filename = f"{dest_base}.{ext}"
+    filename = f"{uuid.uuid4().hex}.png"
     path = os.path.join("static", filename)
     try:
         file.seek(0)
@@ -257,9 +253,7 @@ def process_signature(file, dest_base, original_ext):
                 else:
                     new_data.append(item)
             img.putdata(new_data)
-            img.save(path, format="PNG")
-        else:
-            img.save(path)
+        img.save(path, format="PNG")
     except Exception:
         logger.exception("Failed to process signature image")
         raise


### PR DESCRIPTION
## Summary
- implement `process_signature(file)` helper
- use it when saving signatures
- document dependency and background removal
- update tests for new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a90a7858832a8a8105fff6dd1110