### PR TITLE
Add login and access tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,5 +101,4 @@ Install pytest and run the test suite with:
 pip install pytest
 pytest
 ```
-
-The tests create a temporary SQLite database and verify basic route availability and registration validation logic.
+The tests create a temporary SQLite database and verify route availability, registration, login, access control and helper utilities.


### PR DESCRIPTION
## Summary
- add tests covering login success, login failure, and protected panel access
- extend utils tests for validate_signature
- update README test instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b034b8b0832a997a6cced1ab8d1c