### PR TITLE
Fix login panel centering

### DIFF
--- a/static/theme.css
+++ b/static/theme.css
@@ -14,3 +14,15 @@ body.high-contrast .btn {
   color: #000 !important;
   border-color: #ff0 !important;
 }
+
+/* Centered login form container */
+.login-box {
+  width: 100%;
+  max-width: 420px;
+  margin: auto;
+  padding: 2rem;
+  border: 1px solid var(--bs-border-color-translucent);
+  border-radius: 0.5rem;
+  background-color: var(--bs-body-bg);
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.1);
+}

--- a/templates/login.html
+++ b/templates/login.html
@@ -4,8 +4,8 @@
 {% block head_extra %}
 {% endblock %}
 {% block content %}
-  <div class="d-flex justify-content-center align-items-center min-vh-100">
-    <div class="login-box">
+  <div class="container py-5 d-flex justify-content-center">
+    <div class="login-box mx-auto">
       <h2 class="mb-4 text-center">Logowanie</h2>
       <form method="POST" action="/login">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">


### PR DESCRIPTION
## Summary
- tweak login page layout to avoid 100vh wrapper and center form
- keep login box responsive with automatic margins

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845bb44dc44832a9df7bf8ece1bac45