### PR TITLE
Remove expand rows from admin view

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -46,7 +46,6 @@
   <table class="table table-striped table-bordered align-middle">
     <thead class="table-dark">
       <tr>
-        <th></th>
         <th>ID</th>
         <th>Imię i nazwisko</th>
         <th>Podpis</th>
@@ -57,12 +56,6 @@
     <tbody>
       {% for p in prowadzacy %}
       <tr>
-        <td class="text-center">
-          <button type="button" class="btn btn-sm" data-bs-toggle="collapse" data-bs-target="#row{{ p.id }}" aria-expanded="false" aria-controls="row{{ p.id }}">
-            <i class="bi bi-caret-right"></i>
-            <span class="visually-hidden">Pokaż listę</span>
-          </button>
-        </td>
         <td>{{ p.id }}</td>
         <td>{{ p.imie }} {{ p.nazwisko }}</td>
         <td>
@@ -89,15 +82,6 @@
             <i class="bi bi-file-earmark-text"></i>
             <span class="visually-hidden">Raport miesięczny</span>
           </button>
-        </td>
-      </tr>
-      <tr class="collapse" id="row{{ p.id }}">
-        <td colspan="6">
-          <ul class="mb-0 mt-2">
-            {% for u in p.uczestnicy %}
-              <li>{{ u.imie_nazwisko }}</li>
-            {% endfor %}
-          </ul>
         </td>
       </tr>
 


### PR DESCRIPTION
## Summary
- simplify the trainers table by removing the collapse column and participants row

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845c3fb02b8832a9aa8b96698ba1c2b