### PR TITLE
Remove collapse rows from history tables

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -123,7 +123,6 @@
   <table class="table table-striped table-hover">
     <thead class="table-secondary">
       <tr>
-        <th></th>
         <th>Data</th>
         <th>Czas trwania</th>
         <th>Prowadzący</th>
@@ -134,12 +133,6 @@
     <tbody>
       {% for z in zajecia %}
       <tr>
-        <td class="text-center">
-          <button type="button" class="btn btn-sm" data-bs-toggle="collapse" data-bs-target="#row{{ z.id }}" aria-expanded="false" aria-controls="row{{ z.id }}">
-            <i class="bi bi-caret-right"></i>
-            <span class="visually-hidden">Pokaż listę</span>
-          </button>
-        </td>
         <td>{{ z.data }}</td>
         <td>{{ z.czas_trwania }}</td>
         <td>{{ z.prowadzacy.imie }} {{ z.prowadzacy.nazwisko }}</td>
@@ -160,15 +153,6 @@
               <span class="visually-hidden">Usuń zajęcia</span>
             </button>
           </form>
-        </td>
-      </tr>
-      <tr class="collapse" id="row{{ z.id }}">
-        <td colspan="6">
-          <ul class="mb-0 mt-2">
-            {% for o in z.obecni %}
-              <li>{{ o.imie_nazwisko }}</li>
-            {% endfor %}
-          </ul>
         </td>
       </tr>
       {% endfor %}

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -51,7 +51,6 @@
   <table class="table table-striped table-hover">
     <thead class="table-secondary">
       <tr>
-        <th></th>
         <th>Data</th>
         <th>Czas</th>
         <th>Obecni</th>
@@ -61,12 +60,6 @@
     <tbody>
       {% for z in zajecia %}
       <tr>
-        <td class="text-center">
-          <button type="button" class="btn btn-sm" data-bs-toggle="collapse" data-bs-target="#row{{ z.id }}" aria-expanded="false" aria-controls="row{{ z.id }}">
-            <i class="bi bi-caret-right"></i>
-            <span class="visually-hidden">Pokaż listę</span>
-          </button>
-        </td>
         <td>{{ z.data.date() }}</td>
         <td>{{ z.czas_trwania }}</td>
         <td>{{ z.obecni|length }}</td>
@@ -86,15 +79,6 @@
               <span class="visually-hidden">Usuń zajęcia</span>
             </button>
           </form>
-        </td>
-      </tr>
-      <tr class="collapse" id="row{{ z.id }}">
-        <td colspan="5">
-          <ul class="mb-0 mt-2">
-            {% for o in z.obecni %}
-              <li>{{ o.imie_nazwisko }}</li>
-            {% endfor %}
-          </ul>
         </td>
       </tr>
       {% endfor %}


### PR DESCRIPTION
## Summary
- clean up history tables in admin and panel views by removing expand button column
- delete attendee collapse rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c5f895e4832a8db241d9babc800d