### PR TITLE
Display total participants in history tables

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -136,7 +136,7 @@
         <td>{{ z.data }}</td>
         <td>{{ z.czas_trwania }}</td>
         <td>{{ z.prowadzacy.imie }} {{ z.prowadzacy.nazwisko }}</td>
-        <td>{{ z.obecni|length }}</td>
+        <td>{{ z.obecni|length }}/{{ z.prowadzacy.uczestnicy|length }}</td>
         <td class="text-nowrap">
           <a href="{{ url_for('routes.edytuj_zajecie', id=z.id) }}" class="btn btn-sm" aria-label="Edytuj zajęcia">
             <i class="bi bi-pencil"></i>

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -62,7 +62,7 @@
       <tr>
         <td>{{ z.data.date() }}</td>
         <td>{{ z.czas_trwania }}</td>
-        <td>{{ z.obecni|length }}</td>
+        <td>{{ z.obecni|length }}/{{ z.prowadzacy.uczestnicy|length }}</td>
         <td class="text-nowrap">
           <a href="{{ url_for('routes.panel_edytuj_zajecie', id=z.id) }}" class="btn btn-sm" aria-label="Edytuj zajęcia">
             <i class="bi bi-pencil"></i>


### PR DESCRIPTION
## Summary
- show the total number of participants in history tables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845c7c36308832a9240f74e49a0a558