### PR TITLE
Add trainer report modal

### DIFF
--- a/templates/panel.html
+++ b/templates/panel.html
@@ -47,6 +47,10 @@
     <button type="submit" class="btn btn-primary">Zapisz listę</button>
   </form>
 
+  <div class="mb-5">
+    <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#raportModal">Raport miesięczny</button>
+  </div>
+
   <h2 class="mb-4">Historia zajęć</h2>
   <table class="table table-striped table-hover">
     <thead class="table-secondary">
@@ -84,4 +88,32 @@
       {% endfor %}
     </tbody>
   </table>
+
+  <div class="modal fade" id="raportModal" tabindex="-1" aria-labelledby="raportModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form method="GET" action="{{ url_for('routes.panel_raport') }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <div class="modal-header">
+            <h5 class="modal-title" id="raportModalLabel">Raport miesięczny</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>
+          </div>
+          <div class="modal-body">
+            <div class="form-floating mb-3">
+              <input type="number" class="form-control" id="miesiac" name="miesiac" placeholder="Miesiąc" value="{{ ostatnie.data.month if ostatnie }}" required tabindex="1">
+              <label for="miesiac">Miesiąc:</label>
+            </div>
+            <div class="form-floating mb-3">
+              <input type="number" class="form-control" id="rok" name="rok" placeholder="Rok" value="{{ ostatnie.data.year if ostatnie }}" required tabindex="2">
+              <label for="rok">Rok:</label>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="submit" class="btn btn-primary" tabindex="3">Pobierz</button>
+            <button type="submit" name="wyslij" value="1" class="btn btn-outline-secondary" tabindex="4">Wyślij mailem</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -139,3 +139,9 @@ def test_panel_requires_login(client):
     resp = client.get('/panel')
     assert resp.status_code == 302
     assert '/login' in resp.headers['Location']
+
+
+def test_panel_raport_requires_login(client):
+    resp = client.get('/panel/raport')
+    assert resp.status_code == 302
+    assert '/login' in resp.headers['Location']


### PR DESCRIPTION
## Summary
- support generating monthly reports for trainers
- allow downloading or emailing the monthly report from the trainer panel
- test that the new panel report route requires login

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c9c06c3c832aa67e9ad6b44f6ba7