### PR TITLE
Add async email queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ You can export them in your shell or copy `.env.example` to `.env` when using do
 
 A `.dockerignore` file keeps the image small by skipping development files like `.git` and the `migrations` directory when building.
 
+### Asynchronous e-mail sending
+
+The helper functions `send_plain_email` and `email_do_koordynatora` accept a
+`queue=True` argument. When enabled, outgoing messages are queued and delivered
+by a background thread instead of being sent immediately.
+
 ## Database setup
 
 Install the required packages first:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -66,3 +66,22 @@ def test_validate_signature_exception():
     fs = FileStorage(FailingStream(b'x'), filename='sig.png', content_type='image/png')
     with pytest.raises(utils.SignatureValidationError):
         utils.validate_signature(fs)
+
+
+def test_send_plain_email_queue(monkeypatch):
+    called = {}
+
+    def fake_send(msg):
+        called['to'] = msg['To']
+
+    monkeypatch.setattr(utils, '_send_message', fake_send)
+    utils.send_plain_email(
+        'x@example.com',
+        'SUBJ',
+        'BODY',
+        's',
+        'b',
+        queue=True,
+    )
+    utils._email_queue.join()
+    assert called.get('to') == 'x@example.com'


### PR DESCRIPTION
## Summary
- add simple background queue and worker thread for e-mail sending
- support `queue=True` in `send_plain_email` and `email_do_koordynatora`
- document asynchronous mode
- test queued mail sending

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d1b093cc832aa35150d5cace003f