### PR TITLE
Fix admin date formatting

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -133,7 +133,7 @@
     <tbody>
       {% for z in zajecia %}
       <tr>
-        <td>{{ z.data }}</td>
+        <td>{{ z.data.date() }}</td>
         <td>{{ z.czas_trwania }}</td>
         <td>{{ z.prowadzacy.imie }} {{ z.prowadzacy.nazwisko }}</td>
         <td>{{ z.obecni|length }}/{{ z.prowadzacy.uczestnicy|length }}</td>


### PR DESCRIPTION
## Summary
- show only the date for sessions in admin history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68473c13d240832abd3ef73b0648931c