### PR TITLE
Add email send for admin session

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -146,6 +146,10 @@
             <i class="bi bi-download"></i>
             <span class="visually-hidden">Pobierz dokument</span>
           </a>
+          <a href="{{ url_for('routes.wyslij_zajecie_admin', id=z.id) }}" class="btn btn-sm text-secondary" aria-label="Wyślij dokument mailem">
+            <i class="bi bi-envelope"></i>
+            <span class="visually-hidden">Wyślij dokument mailem</span>
+          </a>
           <form action="{{ url_for('routes.usun_zajecie', id=z.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć zajęcia?')">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń zajęcia">


### PR DESCRIPTION
## Summary
- allow admins to email an attendance list for a session
- add "send" button in the admin panel
- test admin send route and login requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68473d490c78832aa3133538b58224a4