### PR TITLE
Add remember me option

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -23,6 +23,7 @@ def login():
     if request.method == "POST":
         login_val = request.form.get("login")
         haslo = request.form.get("hasło")
+        remember = bool(request.form.get("remember"))
 
         if not is_valid_email(login_val):
             flash("Login musi być prawidłowym adresem e-mail", "danger")
@@ -34,7 +35,7 @@ def login():
                 flash("Konto prowadzącego nie zostało jeszcze zatwierdzone", "danger")
                 return redirect(url_for("routes.login"))
 
-            login_user(user)
+            login_user(user, remember=remember)
 
             if user.role == "admin":
                 return redirect(url_for("routes.admin_dashboard"))

--- a/templates/login.html
+++ b/templates/login.html
@@ -35,6 +35,10 @@
           {% endif %}
         {% endwith %}
       </div>
+      <div class="form-check mt-3">
+        <input type="checkbox" class="form-check-input" id="remember" name="remember">
+        <label class="form-check-label" for="remember">Zapamiętaj mnie</label>
+      </div>
       <div class="d-grid mt-3">
         <button type="submit" class="btn btn-primary" tabindex="3">Zaloguj się</button>
       </div>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -125,6 +125,28 @@ def test_login_success(client, app):
     assert resp.headers['Location'].endswith('/admin')
 
 
+def test_login_remember_sets_cookie(client, app):
+    with app.app_context():
+        user = Uzytkownik(
+            login='perm@example.com',
+            haslo_hash=generate_password_hash('secret'),
+            role='admin',
+            approved=True,
+        )
+        db.session.add(user)
+        db.session.commit()
+
+    resp = client.post(
+        '/login',
+        data={'login': 'perm@example.com', 'hasło': 'secret', 'remember': '1'},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    cookie = client._cookies.get(('localhost', '/', 'remember_token'))
+    assert cookie is not None
+    assert cookie.expires is not None
+
+
 def test_login_failure(client, app):
     with app.app_context():
         user = Uzytkownik(login='adm2@example.com',


### PR DESCRIPTION
## Summary
- add checkbox for 'remember me' on login page
- pass 'remember' flag to `login_user`
- test that remember cookie is set when logging in with the option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684746ed954c832aab7680e25eabbe85