### PR TITLE
Add password toggle buttons

### DIFF
--- a/static/theme.js
+++ b/static/theme.js
@@ -22,6 +22,18 @@ function toggleContrast() {
   localStorage.setItem('contrast', active ? '1' : '0');
 }
 
+function togglePassword(id, btn) {
+  const input = document.getElementById(id);
+  if (!input) return;
+  const icon = btn && btn.querySelector('i');
+  const show = input.type === 'password';
+  input.type = show ? 'text' : 'password';
+  if (icon) {
+    icon.classList.toggle('bi-eye', !show);
+    icon.classList.toggle('bi-eye-slash', show);
+  }
+}
+
 (function() {
   let theme = localStorage.getItem('theme');
   if (!theme) {

--- a/templates/login.html
+++ b/templates/login.html
@@ -22,9 +22,12 @@
         <input type="email" class="form-control" id="login" name="login" placeholder="Login" required autocomplete="username" tabindex="1">
         <label for="login">Login:</label>
       </div>
-      <div class="form-floating mb-3">
+      <div class="form-floating mb-3 position-relative">
         <input type="password" class="form-control" id="hasło" name="hasło" placeholder="Hasło" required autocomplete="current-password" tabindex="2">
         <label for="hasło">Hasło:</label>
+        <button type="button" class="btn btn-outline-secondary border-0 position-absolute top-50 end-0 translate-middle-y" onclick="togglePassword('hasło', this)" tabindex="-1" aria-label="Pokaż lub ukryj hasło">
+          <i class="bi bi-eye"></i>
+        </button>
       </div>
       <div aria-live="polite" role="status">
         {% with messages = get_flashed_messages(with_categories=true) %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -25,9 +25,12 @@
         <input type="email" class="form-control" id="login" name="login" placeholder="Login" required autocomplete="username" tabindex="5">
         <label for="login">Login (adres e-mail):</label>
       </div>
-      <div class="form-floating mb-3">
+      <div class="form-floating mb-3 position-relative">
         <input type="password" class="form-control" id="haslo" name="haslo" placeholder="Hasło" required autocomplete="new-password" tabindex="6">
         <label for="haslo">Hasło:</label>
+        <button type="button" class="btn btn-outline-secondary border-0 position-absolute top-50 end-0 translate-middle-y" onclick="togglePassword('haslo', this)" tabindex="-1" aria-label="Pokaż lub ukryj hasło">
+          <i class="bi bi-eye"></i>
+        </button>
       </div>
       <div class="form-floating mb-3">
         <input type="file" class="form-control" id="podpis" name="podpis" accept=".png,.jpg,.jpeg" tabindex="7">


### PR DESCRIPTION
## Summary
- add password toggle function to JS
- show/hide password icon in login form
- show/hide password icon in register form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684752f77320832aa06459ff73f0aad1