### PR TITLE
Add forgotten password link to login page

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -49,6 +49,9 @@
     <div class="text-center mt-3">
       <a href="{{ url_for('routes.register') }}" tabindex="4">Zarejestruj się</a>
     </div>
+    <div class="text-center mt-2">
+      <a href="{{ url_for('routes.reset_request') }}" tabindex="5">Nie pamiętasz hasła?</a>
+    </div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a password reset link below the registration link on the login page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847569abdd0832ab0ca4631d4e34d7f