### PR TITLE
Add signature image preview

### DIFF
--- a/static/theme.js
+++ b/static/theme.js
@@ -49,5 +49,24 @@ function togglePassword(id, btn) {
     if (darkBtn) darkBtn.addEventListener('click', toggleTheme);
     const contrastBtn = document.getElementById('contrastToggle');
     if (contrastBtn) contrastBtn.addEventListener('click', toggleContrast);
+
+    const sigInput = document.getElementById('podpis');
+    const sigPreview = document.getElementById('podpisPreview');
+    if (sigInput && sigPreview) {
+      sigInput.addEventListener('change', function () {
+        const file = this.files && this.files[0];
+        if (file && file.type.startsWith('image/')) {
+          const reader = new FileReader();
+          reader.onload = function (e) {
+            sigPreview.src = e.target.result;
+            sigPreview.classList.remove('d-none');
+          };
+          reader.readAsDataURL(file);
+        } else {
+          sigPreview.classList.add('d-none');
+          sigPreview.removeAttribute('src');
+        }
+      });
+    }
   });
 })();

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -30,6 +30,7 @@
       <div class="col-md-6">
         <label for="podpis" class="form-label">Podpis (.png/.jpg):</label>
         <input type="file" class="form-control" id="podpis" name="podpis" accept=".png,.jpg,.jpeg">
+        <img id="podpisPreview" class="img-thumbnail mt-2 d-none" alt="Podgląd podpisu">
       </div>
     </div>
     <div class="mt-3">

--- a/templates/register.html
+++ b/templates/register.html
@@ -35,6 +35,7 @@
       <div class="form-floating mb-3">
         <input type="file" class="form-control" id="podpis" name="podpis" accept=".png,.jpg,.jpeg" tabindex="7">
         <label for="podpis">Podpis (.png lub .jpg, opcjonalnie):</label>
+        <img id="podpisPreview" class="img-thumbnail mt-2 d-none" alt="Podgląd podpisu">
       </div>
       <div aria-live="polite" role="status">
         {% with messages = get_flashed_messages(with_categories=True) %}


### PR DESCRIPTION
## Summary
- show image preview for the signature upload on registration and trainer panel pages
- update JS to handle preview visibility

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68475779ecfc832a93af40886d7f2a2a