### PR TITLE
Add email sending for trainer sessions

### DIFF
--- a/templates/panel.html
+++ b/templates/panel.html
@@ -77,6 +77,10 @@
             <i class="bi bi-download"></i>
             <span class="visually-hidden">Pobierz dokument</span>
           </a>
+          <a href="{{ url_for('routes.wyslij_zajecie', id=z.id) }}" class="btn btn-sm text-secondary" aria-label="Wyślij dokument mailem">
+            <i class="bi bi-envelope"></i>
+            <span class="visually-hidden">Wyślij dokument mailem</span>
+          </a>
           <form action="{{ url_for('routes.usun_moje_zajecie', id=z.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Usunąć zajęcia?')">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń zajęcia">


### PR DESCRIPTION
## Summary
- allow trainers to e-mail an attendance list
- expose `wyslij_zajecie` route
- show a button for sending a list on the trainer panel
- test e-mail sending via trainer route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475d85d8b4832a8b3cfebae5847f7b