### PR TITLE
Display stored signature in panel

### DIFF
--- a/templates/panel.html
+++ b/templates/panel.html
@@ -30,6 +30,12 @@
       <div class="col-md-6">
         <label for="podpis" class="form-label">Podpis (.png/.jpg):</label>
         <input type="file" class="form-control" id="podpis" name="podpis" accept=".png,.jpg,.jpeg">
+        {% if prowadzacy.podpis_filename %}
+          <img src="{{ url_for('static', filename=prowadzacy.podpis_filename) }}"
+               alt="Aktualny podpis"
+               class="img-thumbnail mt-2"
+               style="height: 60px;">
+        {% endif %}
         <img id="podpisPreview" class="img-thumbnail mt-2 d-none" alt="Podgląd podpisu">
       </div>
     </div>


### PR DESCRIPTION
## Summary
- show existing signature image in panel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475fe38750832a88910578cb44cf8e