### PR TITLE
Add default time field in profile

### DIFF
--- a/routes/panel.py
+++ b/routes/panel.py
@@ -39,12 +39,18 @@ def panel():
         .order_by(Zajecia.data.desc())
         .first()
     )
+    domyslny_czas = (
+        str(prow.domyslny_czas).replace('.', ',').rstrip('0').rstrip(',')
+        if prow.domyslny_czas is not None
+        else ''
+    )
     return render_template(
         'panel.html',
         prowadzacy=prow,
         uczestnicy=uczestnicy,
         zajecia=zajecia,
         ostatnie=ostatnie,
+        domyslny_czas=domyslny_czas,
     )
 
 
@@ -61,6 +67,14 @@ def panel_update_profile():
     prow.imie = request.form.get('imie')
     prow.nazwisko = request.form.get('nazwisko')
     prow.numer_umowy = request.form.get('numer_umowy')
+    czas_val = request.form.get('domyslny_czas', '').strip()
+    if czas_val:
+        try:
+            prow.domyslny_czas = float(czas_val.replace(',', '.'))
+        except ValueError:
+            prow.domyslny_czas = None
+    else:
+        prow.domyslny_czas = None
 
     podpis = request.files.get('podpis')
     sanitized = None

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -27,6 +27,10 @@
         <label for="numer_umowy" class="form-label">Numer umowy:</label>
         <input type="text" class="form-control" id="numer_umowy" name="numer_umowy" value="{{ prowadzacy.numer_umowy }}">
       </div>
+      <div class="col-md-4">
+        <label for="domyslny_czas" class="form-label">Domyślny czas zajęć:</label>
+        <input type="text" class="form-control" id="domyslny_czas" name="domyslny_czas" value="{{ domyslny_czas }}">
+      </div>
       <div class="col-md-6">
         <label for="podpis" class="form-label">Podpis (.png/.jpg):</label>
         <input type="file" class="form-control" id="podpis" name="podpis" accept=".png,.jpg,.jpeg">

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -401,3 +401,18 @@ def test_admin_dashboard_filter(client, app):
     data = resp.data.decode()
     assert '2023-01-01' in data
     assert '2023-01-02' not in data
+
+
+def test_update_default_time(client, app):
+    login_val = _create_trainer(app)
+    client.post('/login', data={'login': login_val, 'hasło': 'pass'}, follow_redirects=False)
+    resp = client.post('/panel/profil', data={
+        'imie': 'T',
+        'nazwisko': 'T',
+        'numer_umowy': '1',
+        'domyslny_czas': '2,5',
+    }, follow_redirects=False)
+    assert resp.status_code == 302
+    with app.app_context():
+        prow = Prowadzacy.query.first()
+        assert prow.domyslny_czas == 2.5


### PR DESCRIPTION
## Summary
- show trainer default time on profile page
- save default time in `panel_update_profile`
- add "Domyślny czas zajęć" input in profile form
- test updating default time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684760f31c44832a8d83c763487336ed