### PR TITLE
Add wyslano flag to sessions

### DIFF
--- a/migrations/versions/9a7f05de6966_add_wyslano_column.py
+++ b/migrations/versions/9a7f05de6966_add_wyslano_column.py
@@ -1,0 +1,24 @@
+"""add wyslano flag to sessions
+
+Revision ID: 9a7f05de6966
+Revises: e203a8fa7c0d
+Create Date: 2025-07-10 12:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '9a7f05de6966'
+down_revision = 'e203a8fa7c0d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('zajecia', sa.Column('wyslano', sa.Boolean(), nullable=True, server_default=sa.text('0')))
+    conn = op.get_bind()
+    conn.execute(sa.text('UPDATE zajecia SET wyslano=1'))
+    op.alter_column('zajecia', 'wyslano', server_default=None, nullable=False)
+
+
+def downgrade():
+    op.drop_column('zajecia', 'wyslano')

--- a/model.py
+++ b/model.py
@@ -44,6 +44,7 @@ class Zajecia(db.Model):
     prowadzacy_id = db.Column(db.Integer, db.ForeignKey("prowadzacy.id"))
     data = db.Column(db.DateTime)
     czas_trwania = db.Column(db.Float)
+    wyslano = db.Column(db.Boolean, default=False)
 
     prowadzacy = db.relationship("Prowadzacy", back_populates="zajecia")
     obecni = db.relationship("Uczestnik", secondary=obecnosci, back_populates="zajecia")

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -382,6 +382,8 @@ def wyslij_zajecie_admin(id):
 
     try:
         email_do_koordynatora(buf, data_str, typ='lista')
+        zaj.wyslano = True
+        db.session.commit()
         flash('Lista została wysłana e-mailem', 'success')
     except smtplib.SMTPException:
         logger.exception('Failed to send attendance email')

--- a/routes/panel.py
+++ b/routes/panel.py
@@ -192,6 +192,8 @@ def wyslij_zajecie(id):
 
     try:
         email_do_koordynatora(buf, data_str, typ='lista')
+        zaj.wyslano = True
+        db.session.commit()
         flash('Lista została wysłana e-mailem', 'success')
     except smtplib.SMTPException:
         logger.exception('Failed to send attendance email')

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -176,6 +176,9 @@
               <span class="visually-hidden">Usuń zajęcia</span>
             </button>
           </form>
+          {% if z.wyslano %}
+          <i class="bi bi-check-lg text-success"></i>
+          {% endif %}
         </td>
       </tr>
       {% endfor %}

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -113,6 +113,9 @@
               <span class="visually-hidden">Usuń zajęcia</span>
             </button>
           </form>
+          {% if z.wyslano %}
+          <i class="bi bi-check-lg text-success"></i>
+          {% endif %}
         </td>
       </tr>
       {% endfor %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -323,6 +323,8 @@ def test_wyslij_zajecie_success(client, app, monkeypatch):
     assert resp.status_code == 302
     assert resp.headers['Location'].endswith('/panel')
     assert called.get('sent')
+    with app.app_context():
+        assert Zajecia.query.get(zaj_id).wyslano is True
 
 
 def test_wyslij_zajecie_admin_requires_login(client):
@@ -363,6 +365,8 @@ def test_wyslij_zajecie_admin_success(client, app, monkeypatch):
     assert resp.status_code == 302
     assert resp.headers['Location'].endswith('/admin')
     assert called.get('sent')
+    with app.app_context():
+        assert Zajecia.query.get(zaj_id).wyslano is True
 
 
 def test_wyslij_zajecie_admin_requires_admin(client, app):


### PR DESCRIPTION
## Summary
- track if a session's attendance list was sent
- add alembic migration to set existing sessions as sent
- mark sessions as sent in panel/admin send actions
- display a check icon for sent sessions
- test persistence of the new flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684800b4a764832ab450b5308cdb747d