### PR TITLE
Add monthly summary table

### DIFF
--- a/routes/panel.py
+++ b/routes/panel.py
@@ -2,6 +2,7 @@ from flask import render_template, redirect, url_for, flash, send_file, request,
 from flask_login import login_required, current_user
 from io import BytesIO
 from model import db, Uczestnik, Zajecia
+from collections import defaultdict
 from doc_generator import generuj_liste_obecnosci, generuj_raport_miesieczny
 from datetime import datetime
 from . import routes_bp
@@ -44,6 +45,10 @@ def panel():
         if prow.domyslny_czas is not None
         else ''
     )
+    podsumowanie = defaultdict(float)
+    for z in zajecia:
+        key = (z.data.year, z.data.month)
+        podsumowanie[key] += z.czas_trwania
     return render_template(
         'panel.html',
         prowadzacy=prow,
@@ -51,6 +56,7 @@ def panel():
         zajecia=zajecia,
         ostatnie=ostatnie,
         domyslny_czas=domyslny_czas,
+        podsumowanie=podsumowanie,
     )
 
 

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -73,9 +73,30 @@
     {% endfor %}
   </ul>
 
-  <div class="mb-5">
-    <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#raportModal">Raport miesięczny</button>
-  </div>
+  <h2 class="mb-4">Raporty miesięczne</h2>
+  <table class="table table-striped table-hover mb-5">
+    <thead class="table-secondary">
+      <tr>
+        <th>Rok</th>
+        <th>Miesiąc</th>
+        <th>Godzin</th>
+        <th>Akcja</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for (rok, miesiac), godziny in podsumowanie|dictsort(reverse=True) %}
+      <tr>
+        <td>{{ rok }}</td>
+        <td>{{ '%02d'|format(miesiac) }}</td>
+        <td>{{ godziny }}</td>
+        <td class="text-nowrap">
+          <a href="{{ url_for('routes.panel_raport') }}?rok={{ rok }}&miesiac={{ miesiac }}" class="btn btn-sm text-primary">Pobierz</a>
+          <a href="{{ url_for('routes.panel_raport') }}?rok={{ rok }}&miesiac={{ miesiac }}&wyslij=1" class="btn btn-sm text-secondary">Wyślij</a>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
 
   <h2 class="mb-4">Historia zajęć</h2>
   <table class="table table-striped table-hover">
@@ -122,31 +143,4 @@
     </tbody>
   </table>
 
-  <div class="modal fade" id="raportModal" tabindex="-1" aria-labelledby="raportModalLabel" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <form method="GET" action="{{ url_for('routes.panel_raport') }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-          <div class="modal-header">
-            <h5 class="modal-title" id="raportModalLabel">Raport miesięczny</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>
-          </div>
-          <div class="modal-body">
-            <div class="form-floating mb-3">
-              <input type="number" class="form-control" id="miesiac" name="miesiac" placeholder="Miesiąc" value="{{ ostatnie.data.month if ostatnie }}" required tabindex="1">
-              <label for="miesiac">Miesiąc:</label>
-            </div>
-            <div class="form-floating mb-3">
-              <input type="number" class="form-control" id="rok" name="rok" placeholder="Rok" value="{{ ostatnie.data.year if ostatnie }}" required tabindex="2">
-              <label for="rok">Rok:</label>
-            </div>
-          </div>
-          <div class="modal-footer">
-            <button type="submit" class="btn btn-primary" tabindex="3">Pobierz</button>
-            <button type="submit" name="wyslij" value="1" class="btn btn-outline-secondary" tabindex="4">Wyślij mailem</button>
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
 {% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -529,3 +529,14 @@ def test_reset_with_token_purges_expired(client, app):
     with app.app_context():
         assert PasswordResetToken.query.filter_by(token='old').first() is None
         assert PasswordResetToken.query.filter_by(token=token_value).first() is not None
+
+
+def test_panel_summary_table_links(client, app):
+    login_val = _create_trainer(app)
+    client.post('/login', data={'login': login_val, 'hasło': 'pass'}, follow_redirects=False)
+    resp = client.get('/panel')
+    assert resp.status_code == 200
+    data = resp.data.decode()
+    assert 'Raporty miesięczne' in data
+    assert '/panel/raport?rok=2023&miesiac=5' in data
+    assert '/panel/raport?rok=2023&miesiac=5&wyslij=1' in data


### PR DESCRIPTION
## Summary
- group hours by (year, month) for logged-in trainer
- display monthly summaries on the trainer panel with download and send links
- remove old modal interface
- verify new links appear with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684803587924832a9b4a6b591f4f368e