### PR TITLE
Add trainer attendance statistics

### DIFF
--- a/templates/panel.html
+++ b/templates/panel.html
@@ -73,6 +73,10 @@
     {% endfor %}
   </ul>
 
+  <p>
+    <a href="{{ url_for('routes.panel_statystyki') }}" class="btn btn-outline-secondary">Statystyki obecności</a>
+  </p>
+
   <h2 class="mb-4">Raporty miesięczne</h2>
   <table class="table table-striped table-hover mb-5">
     <thead class="table-secondary">

--- a/templates/statystyki.html
+++ b/templates/statystyki.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block title %}Statystyki{% endblock %}
+{% block content %}
+  <h2 class="mb-4">Statystyki obecności</h2>
+  <table class="table table-striped table-hover mb-4">
+    <thead class="table-secondary">
+      <tr>
+        <th>Uczestnik</th>
+        <th>Obecności</th>
+        <th>Frekwencja</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in stats %}
+      <tr>
+        <td>{{ row.uczestnik.imie_nazwisko }}</td>
+        <td>{{ row.present }}/{{ total_sessions }}</td>
+        <td>{{ '%.0f'|format(row.percent) }}%</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <a href="{{ url_for('routes.panel') }}" class="btn btn-secondary">Powrót</a>
+{% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -540,3 +540,28 @@ def test_panel_summary_table_links(client, app):
     assert 'Raporty miesięczne' in data
     assert '/panel/raport?rok=2023&miesiac=5' in data
     assert '/panel/raport?rok=2023&miesiac=5&wyslij=1' in data
+
+
+def test_panel_statystyki_requires_login(client):
+    resp = client.get('/panel/statystyki')
+    assert resp.status_code == 302
+    assert '/login' in resp.headers['Location']
+
+
+def test_panel_statystyki_data(client, app):
+    login_val = _create_trainer(app)
+    with app.app_context():
+        prow = Prowadzacy.query.first()
+        u1 = Uczestnik(imie_nazwisko='A', prowadzacy_id=prow.id)
+        u2 = Uczestnik(imie_nazwisko='B', prowadzacy_id=prow.id)
+        db.session.add_all([u1, u2])
+        zaj = Zajecia.query.first()
+        zaj.obecni.append(u1)
+        db.session.commit()
+
+    client.post('/login', data={'login': login_val, 'hasło': 'pass'}, follow_redirects=False)
+    resp = client.get('/panel/statystyki')
+    assert resp.status_code == 200
+    data = resp.data.decode()
+    assert 'A' in data and '1/1' in data and '100%' in data
+    assert 'B' in data and '0/1' in data and '0%' in data


### PR DESCRIPTION
## Summary
- add `/panel/statystyki` route showing attendance stats for each participant
- create `statystyki.html` template
- link stats page from trainer panel
- test new route and statistics calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684804b5c6bc832aa70d256e9b319e75