### PR TITLE
Replace deprecated query.get

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -84,7 +84,7 @@ def admin_settings():
                 val = request.form.get(key)
             if val is None:
                 continue
-            setting = Setting.query.get(key)
+            setting = db.session.get(Setting, key)
             if setting:
                 setting.value = val
             else:
@@ -106,7 +106,7 @@ def admin_settings():
 
     values = {}
     for key in keys:
-        setting = Setting.query.get(key)
+        setting = db.session.get(Setting, key)
         values[key] = os.getenv(key.upper(), setting.value if setting else '')
 
     admin_user = Uzytkownik.query.filter_by(role='admin').first()
@@ -119,7 +119,7 @@ def usun_zajecie(id):
     if current_user.role != 'admin':
         abort(403)
 
-    zaj = Zajecia.query.get(id)
+    zaj = db.session.get(Zajecia, id)
     if not zaj:
         abort(404)
 
@@ -134,7 +134,7 @@ def raport(prowadzacy_id):
     if current_user.role != 'admin':
         abort(403)
 
-    prow = Prowadzacy.query.get(prowadzacy_id)
+    prow = db.session.get(Prowadzacy, prowadzacy_id)
     if not prow:
         abort(404)
 
@@ -190,7 +190,7 @@ def dodaj_prowadzacego():
         return redirect(url_for('routes.admin_dashboard'))
 
     if id_edit:
-        prow = Prowadzacy.query.get(id_edit)
+        prow = db.session.get(Prowadzacy, id_edit)
         if not prow:
             flash('Nie znaleziono prowadącego', 'danger')
             return redirect(url_for('routes.admin_dashboard'))
@@ -236,7 +236,7 @@ def usun_prowadzacego(id):
     if current_user.role != 'admin':
         abort(403)
 
-    prow = Prowadzacy.query.get(id)
+    prow = db.session.get(Prowadzacy, id)
     if not prow:
         abort(404)
 
@@ -254,7 +254,7 @@ def approve_user(id):
     if current_user.role != 'admin':
         abort(403)
 
-    user = Uzytkownik.query.get(id)
+    user = db.session.get(Uzytkownik, id)
     if not user:
         flash('Nie znaleziono użytkownika', 'danger')
         return redirect(url_for('routes.admin_dashboard'))
@@ -284,7 +284,7 @@ def edytuj_zajecie(id):
     if current_user.role != 'admin':
         abort(403)
 
-    zaj = Zajecia.query.get(id)
+    zaj = db.session.get(Zajecia, id)
     if not zaj:
         abort(404)
 
@@ -328,7 +328,7 @@ def pobierz_zajecie_admin(id):
     if current_user.role != 'admin':
         abort(403)
 
-    zaj = Zajecia.query.get(id)
+    zaj = db.session.get(Zajecia, id)
     if not zaj:
         abort(404)
 
@@ -361,7 +361,7 @@ def wyslij_zajecie_admin(id):
     if current_user.role != 'admin':
         abort(403)
 
-    zaj = Zajecia.query.get(id)
+    zaj = db.session.get(Zajecia, id)
     if not zaj:
         abort(404)
 

--- a/routes/attendance.py
+++ b/routes/attendance.py
@@ -23,7 +23,7 @@ def index():
             selected_id = int(request.form.get('prowadzący'))
         except (TypeError, ValueError):
             selected_id = prowadzacy[0].id if prowadzacy else None
-        wybrany = Prowadzacy.query.get(selected_id)
+        wybrany = db.session.get(Prowadzacy, selected_id)
     else:
         wybrany = current_user.prowadzacy
         prowadzacy = [wybrany] if wybrany else []

--- a/routes/panel.py
+++ b/routes/panel.py
@@ -136,7 +136,7 @@ def usun_uczestnika(id):
     if current_user.role != 'prowadzacy':
         abort(403)
 
-    uczestnik = Uczestnik.query.get(id)
+    uczestnik = db.session.get(Uczestnik, id)
     if not uczestnik or uczestnik.prowadzacy_id != current_user.prowadzacy_id:
         abort(403)
 
@@ -149,7 +149,7 @@ def usun_uczestnika(id):
 @routes_bp.route('/pobierz_zajecie/<int:id>')
 @login_required
 def pobierz_zajecie(id):
-    zaj = Zajecia.query.get(id)
+    zaj = db.session.get(Zajecia, id)
     if not zaj or zaj.prowadzacy_id != current_user.prowadzacy_id:
         abort(403)
 
@@ -177,7 +177,7 @@ def pobierz_zajecie(id):
 @login_required
 def wyslij_zajecie(id):
     """Send the attendance list for the given session via e-mail."""
-    zaj = Zajecia.query.get(id)
+    zaj = db.session.get(Zajecia, id)
     if not zaj or zaj.prowadzacy_id != current_user.prowadzacy_id:
         abort(403)
 
@@ -211,7 +211,7 @@ def wyslij_zajecie(id):
 @routes_bp.route('/usun_moje_zajecie/<int:id>', methods=['POST'])
 @login_required
 def usun_moje_zajecie(id):
-    zaj = Zajecia.query.get(id)
+    zaj = db.session.get(Zajecia, id)
     if not zaj or zaj.prowadzacy_id != current_user.prowadzacy_id:
         abort(403)
 
@@ -224,7 +224,7 @@ def usun_moje_zajecie(id):
 @routes_bp.route('/panel/edytuj_zajecie/<int:id>', methods=['GET', 'POST'])
 @login_required
 def panel_edytuj_zajecie(id):
-    zaj = Zajecia.query.get(id)
+    zaj = db.session.get(Zajecia, id)
     if not zaj or zaj.prowadzacy_id != current_user.prowadzacy_id:
         abort(403)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -324,7 +324,7 @@ def test_wyslij_zajecie_success(client, app, monkeypatch):
     assert resp.headers['Location'].endswith('/panel')
     assert called.get('sent')
     with app.app_context():
-        assert Zajecia.query.get(zaj_id).wyslano is True
+        assert db.session.get(Zajecia, zaj_id).wyslano is True
 
 
 def test_wyslij_zajecie_admin_requires_login(client):
@@ -366,7 +366,7 @@ def test_wyslij_zajecie_admin_success(client, app, monkeypatch):
     assert resp.headers['Location'].endswith('/admin')
     assert called.get('sent')
     with app.app_context():
-        assert Zajecia.query.get(zaj_id).wyslano is True
+        assert db.session.get(Zajecia, zaj_id).wyslano is True
 
 
 def test_wyslij_zajecie_admin_requires_admin(client, app):
@@ -469,7 +469,7 @@ def test_trainer_delete_participant(client, app):
     assert resp.status_code == 302
     assert resp.headers['Location'].endswith('/panel')
     with app.app_context():
-        assert Uczestnik.query.get(uid) is None
+        assert db.session.get(Uczestnik, uid) is None
 
 
 def test_reset_request_purges_expired_token(client, app, monkeypatch):


### PR DESCRIPTION
## Summary
- modernize DB queries to use `db.session.get` instead of `Model.query.get`
- update tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684806084bf8832ab76bdc9be4489a34