### PR TITLE
Fix wyslano migration

### DIFF
--- a/migrations/versions/9a7f05de6966_add_wyslano_column.py
+++ b/migrations/versions/9a7f05de6966_add_wyslano_column.py
@@ -14,11 +14,16 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column('zajecia', sa.Column('wyslano', sa.Boolean(), nullable=True, server_default=sa.text('0')))
+    with op.batch_alter_table('zajecia') as batch_op:
+        batch_op.add_column(
+            sa.Column('wyslano', sa.Boolean(), nullable=True, server_default=sa.text('0'))
+        )
     conn = op.get_bind()
     conn.execute(sa.text('UPDATE zajecia SET wyslano=1'))
-    op.alter_column('zajecia', 'wyslano', server_default=None, nullable=False)
+    with op.batch_alter_table('zajecia') as batch_op:
+        batch_op.alter_column('wyslano', server_default=None, nullable=False)
 
 
 def downgrade():
-    op.drop_column('zajecia', 'wyslano')
+    with op.batch_alter_table('zajecia') as batch_op:
+        batch_op.drop_column('wyslano')


### PR DESCRIPTION
## Summary
- fix migration to use batch operations for new `wyslano` flag
- drop column with batch operations in downgrade
- run `flask db upgrade` to verify migration

## Testing
- `pip install -r requirements.txt`
- `flask db upgrade`

------
https://chatgpt.com/codex/tasks/task_e_684808f5a210832a98c62e6df453e6da