### PR TITLE
Fix db import in attendance and add admin index test

### DIFF
--- a/routes/attendance.py
+++ b/routes/attendance.py
@@ -1,6 +1,6 @@
 from flask import render_template, request, redirect, url_for, flash, send_file
 from flask_login import current_user, login_required
-from model import Prowadzacy
+from model import db, Prowadzacy
 
 from utils import przetworz_liste_obecnosci, email_do_koordynatora
 from . import routes_bp

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -159,6 +159,25 @@ def test_login_failure(client, app):
     assert b'Nieprawid' in resp.data
 
 
+def test_admin_index_page(client, app):
+    """Loading the attendance page as admin should work."""
+    with app.app_context():
+        prow = Prowadzacy(imie='A', nazwisko='B')
+        db.session.add(prow)
+        admin = Uzytkownik(
+            login='idx@example.com',
+            haslo_hash=generate_password_hash('pass'),
+            role='admin',
+            approved=True,
+        )
+        db.session.add(admin)
+        db.session.commit()
+
+    client.post('/login', data={'login': 'idx@example.com', 'hasło': 'pass'}, follow_redirects=False)
+    resp = client.get('/')
+    assert resp.status_code == 200
+
+
 def test_panel_requires_login(client):
     resp = client.get('/panel')
     assert resp.status_code == 302


### PR DESCRIPTION
## Summary
- import `db` in `routes/attendance.py`
- add regression test ensuring admin can load the root page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68480cab6cc8832a89374c955b952f25