### PR TITLE
Add generate-reports CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ flask purge-tokens
 
 This command removes old entries and can be triggered from cron.
 
+### Generating monthly reports
+
+Use the ``generate-reports`` command to create reports for all trainers with
+sessions in a given month:
+
+```bash
+flask generate-reports --month 5 --year 2025 --email
+```
+
+Reports are saved under ``reports/`` using names like
+``raport_<id>_5_2025.docx``.  When ``--email`` is supplied each generated file
+is also sent to the coordinator.
+
 ## Running tests
 
 Install pytest and run the test suite with:

--- a/app.py
+++ b/app.py
@@ -5,8 +5,11 @@ from flask_wtf import CSRFProtect
 from dotenv import load_dotenv
 import logging
 import os
-from model import db, Uzytkownik
-from utils import load_db_settings, purge_expired_tokens
+from model import db, Uzytkownik, Prowadzacy, Zajecia
+from utils import load_db_settings, purge_expired_tokens, email_do_koordynatora
+from doc_generator import generuj_raport_miesieczny
+from io import BytesIO
+import smtplib
 import click
 
 logger = logging.getLogger(__name__)
@@ -21,9 +24,8 @@ csrf = CSRFProtect()
 
 def inject_is_admin():
     """Expose an ``is_admin`` flag to all templates."""
-    return {
-        "is_admin": current_user.is_authenticated and current_user.role == "admin"
-    }
+    return {"is_admin": current_user.is_authenticated and current_user.role == "admin"}
+
 
 def create_app():
     logging.basicConfig(level=logging.INFO)
@@ -55,12 +57,16 @@ def create_app():
         logger.error("Invalid SMTP_PORT: %s", smtp_port)
         raise RuntimeError("Invalid SMTP_PORT")
 
-    missing = [v for v, val in {
-        "SMTP_HOST": smtp_host,
-        "SMTP_PORT": smtp_port,
-        "EMAIL_LOGIN": email_login,
-        "EMAIL_PASSWORD": email_password,
-    }.items() if not val]
+    missing = [
+        v
+        for v, val in {
+            "SMTP_HOST": smtp_host,
+            "SMTP_PORT": smtp_port,
+            "EMAIL_LOGIN": email_login,
+            "EMAIL_PASSWORD": email_password,
+        }.items()
+        if not val
+    ]
     if missing:
         logger.error("Missing mail configuration: %s", ", ".join(missing))
         raise RuntimeError("Incomplete mail configuration")
@@ -70,6 +76,7 @@ def create_app():
 
     # Rejestracja blueprintów
     from routes import routes_bp
+
     app.register_blueprint(routes_bp)
 
     app.context_processor(inject_is_admin)
@@ -80,19 +87,67 @@ def create_app():
         purge_expired_tokens()
         click.echo("Expired tokens removed")
 
+    @app.cli.command("generate-reports")
+    @click.option("--month", required=True, type=int, help="Month number (1-12)")
+    @click.option("--year", required=True, type=int, help="Full year")
+    @click.option("--email", is_flag=True, help="Send reports via e-mail")
+    def generate_reports_command(month: int, year: int, email: bool) -> None:
+        """Generate monthly reports for all trainers."""
+        if not 1 <= month <= 12 or year < 2000:
+            raise click.BadParameter("Invalid month or year")
+
+        reports_dir = os.path.join("reports")
+        os.makedirs(reports_dir, exist_ok=True)
+
+        with app.app_context():
+            trainers = (
+                db.session.query(Prowadzacy)
+                .join(Zajecia)
+                .filter(
+                    db.extract("month", Zajecia.data) == month,
+                    db.extract("year", Zajecia.data) == year,
+                )
+                .distinct()
+                .all()
+            )
+
+            for trainer in trainers:
+                sessions = Zajecia.query.filter_by(prowadzacy_id=trainer.id).all()
+                doc = generuj_raport_miesieczny(
+                    trainer, sessions, "rejestr.docx", "static", month, year
+                )
+
+                filename = f"raport_{trainer.id}_{month}_{year}.docx"
+                path = os.path.join(reports_dir, filename)
+                doc.save(path)
+                click.echo(f"Saved {path}")
+
+                if email:
+                    buf = BytesIO()
+                    doc.save(buf)
+                    buf.seek(0)
+                    try:
+                        email_do_koordynatora(buf, f"{month}_{year}", typ="raport")
+                        click.echo(f"Sent {filename}")
+                    except smtplib.SMTPException:
+                        logger.exception("Failed to send report e-mail")
+                        click.echo(f"Failed to send e-mail for {filename}", err=True)
+
     @app.errorhandler(403)
     def forbidden(_):
-        return render_template('403.html'), 403
+        return render_template("403.html"), 403
 
     @app.errorhandler(404)
     def not_found(_):
-        return render_template('404.html'), 404
+        return render_template("404.html"), 404
 
     return app
+
 
 @login_manager.user_loader
 def load_user(user_id):
     return db.session.get(Uzytkownik, int(user_id))
+
 
 if __name__ == "__main__":
     app = create_app()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,82 @@
+import os
+from datetime import datetime
+
+import pytest
+from docx import Document
+
+from app import create_app
+from model import db, Prowadzacy, Zajecia
+
+
+@pytest.fixture
+def app(tmp_path):
+    os.environ["SECRET_KEY"] = "test"
+    os.environ["DATABASE_URL"] = "sqlite:///" + str(tmp_path / "db.db")
+    os.environ["MAX_SIGNATURE_SIZE"] = "10"
+    os.environ["SMTP_HOST"] = "smtp"
+    os.environ["SMTP_PORT"] = "25"
+    os.environ["EMAIL_LOGIN"] = "user"
+    os.environ["EMAIL_PASSWORD"] = "pass"
+    application = create_app()
+    application.config["WTF_CSRF_ENABLED"] = False
+    with application.app_context():
+        db.create_all()
+        yield application
+        db.session.remove()
+        db.drop_all()
+
+
+def _setup_data(app):
+    with app.app_context():
+        p1 = Prowadzacy(imie="A", nazwisko="B", podpis_filename="sig.png")
+        p2 = Prowadzacy(imie="C", nazwisko="D", podpis_filename="sig.png")
+        db.session.add_all([p1, p2])
+        db.session.flush()
+        z1 = Zajecia(prowadzacy_id=p1.id, data=datetime(2025, 5, 1), czas_trwania=1.0)
+        z2 = Zajecia(prowadzacy_id=p2.id, data=datetime(2025, 6, 1), czas_trwania=1.0)
+        db.session.add_all([z1, z2])
+        db.session.commit()
+        return p1.id, p2.id
+
+
+def test_generate_reports_file(app, monkeypatch, tmp_path):
+    p1_id, p2_id = _setup_data(app)
+
+    def dummy_report(*_a, **_k):
+        doc = Document()
+        doc.add_paragraph("x")
+        return doc
+
+    monkeypatch.setattr("app.generuj_raport_miesieczny", dummy_report)
+    runner = app.test_cli_runner()
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(args=["generate-reports", "--month", "5", "--year", "2025"])
+    assert result.exit_code == 0
+    expected = tmp_path / "reports" / f"raport_{p1_id}_5_2025.docx"
+    assert expected.exists()
+    not_expected = tmp_path / "reports" / f"raport_{p2_id}_5_2025.docx"
+    assert not not_expected.exists()
+
+
+def test_generate_reports_email(app, monkeypatch, tmp_path):
+    _setup_data(app)
+
+    def dummy_report(*_a, **_k):
+        doc = Document()
+        doc.add_paragraph("x")
+        return doc
+
+    sent = {}
+
+    def fake_email(buf, data, typ=None):
+        sent["called"] = True
+
+    monkeypatch.setattr("app.generuj_raport_miesieczny", dummy_report)
+    monkeypatch.setattr("app.email_do_koordynatora", fake_email)
+    runner = app.test_cli_runner()
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(
+        args=["generate-reports", "--month", "5", "--year", "2025", "--email"]
+    )
+    assert result.exit_code == 0
+    assert sent.get("called")


### PR DESCRIPTION
## Summary
- add `generate-reports` CLI command to app.py
- document command usage in README
- test CLI command (file creation and mailing)

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848129a9dac832aa305d3de7980f651