### PR TITLE
Add repr methods and tests

### DIFF
--- a/model.py
+++ b/model.py
@@ -29,6 +29,9 @@ class Prowadzacy(db.Model):
     zajecia = db.relationship("Zajecia", back_populates="prowadzacy", cascade="all, delete-orphan")
     user = db.relationship("Uzytkownik", back_populates="prowadzacy", uselist=False)
 
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f"<Prowadzacy id={self.id} imie='{self.imie}'>"
+
 class Uczestnik(db.Model):
     __tablename__ = "uczestnik"
     id = db.Column(db.Integer, primary_key=True)
@@ -37,6 +40,9 @@ class Uczestnik(db.Model):
 
     prowadzacy = db.relationship("Prowadzacy", back_populates="uczestnicy")
     zajecia = db.relationship("Zajecia", secondary=obecnosci, back_populates="obecni")
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f"<Uczestnik id={self.id} imie_nazwisko='{self.imie_nazwisko}'>"
 
 class Zajecia(db.Model):
     __tablename__ = "zajecia"
@@ -49,6 +55,10 @@ class Zajecia(db.Model):
     prowadzacy = db.relationship("Prowadzacy", back_populates="zajecia")
     obecni = db.relationship("Uczestnik", secondary=obecnosci, back_populates="zajecia")
 
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        dt = self.data.strftime('%Y-%m-%d') if isinstance(self.data, datetime) else self.data
+        return f"<Zajecia id={self.id} data={dt}>"
+
 class Uzytkownik(UserMixin, db.Model):
     __tablename__ = "uzytkownik"
     id = db.Column(db.Integer, primary_key=True)
@@ -59,6 +69,9 @@ class Uzytkownik(UserMixin, db.Model):
     prowadzacy_id = db.Column(db.Integer, db.ForeignKey("prowadzacy.id"))
 
     prowadzacy = db.relationship("Prowadzacy", back_populates="user")
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f"<Uzytkownik id={self.id} login='{self.login}'>"
 
 
 class Setting(db.Model):

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,0 +1,44 @@
+import os
+from datetime import datetime
+
+import pytest
+
+from app import create_app
+from model import db, Prowadzacy, Uczestnik, Zajecia, Uzytkownik
+from werkzeug.security import generate_password_hash
+
+
+@pytest.fixture
+def app(tmp_path):
+    os.environ['SECRET_KEY'] = 'testsecret'
+    os.environ['DATABASE_URL'] = 'sqlite:///' + str(tmp_path / 'test.db')
+    os.environ['MAX_SIGNATURE_SIZE'] = '10'
+    os.environ['SMTP_HOST'] = 'smtp'
+    os.environ['SMTP_PORT'] = '25'
+    os.environ['EMAIL_LOGIN'] = 'user'
+    os.environ['EMAIL_PASSWORD'] = 'pass'
+    application = create_app()
+    application.config['WTF_CSRF_ENABLED'] = False
+    with application.app_context():
+        db.create_all()
+        yield application
+        db.session.remove()
+        db.drop_all()
+
+
+def test_model_repr(app):
+    with app.app_context():
+        prow = Prowadzacy(imie='Jan', nazwisko='Kowalski')
+        db.session.add(prow)
+        db.session.flush()
+
+        uc = Uczestnik(imie_nazwisko='Anna', prowadzacy_id=prow.id)
+        zaj = Zajecia(prowadzacy_id=prow.id, data=datetime(2023, 1, 1), czas_trwania=1.0)
+        user = Uzytkownik(login='jan@example.com', haslo_hash=generate_password_hash('x'), role='admin')
+        db.session.add_all([uc, zaj, user])
+        db.session.commit()
+
+        assert repr(prow) == f"<Prowadzacy id={prow.id} imie='Jan'>"
+        assert f"imie_nazwisko='Anna'" in repr(uc)
+        assert "data=2023-01-01" in repr(zaj)
+        assert "login='jan@example.com'" in repr(user)


### PR DESCRIPTION
## Summary
- define `__repr__` for core ORM models
- test model string representations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848144f6d14832ab453780912f63890