### PR TITLE
Add trainer participant admin panel

### DIFF
--- a/templates/_trainer_modal.html
+++ b/templates/_trainer_modal.html
@@ -21,17 +21,14 @@
             <input type="text" class="form-control" id="nowy_umowa" name="nowy_umowa" placeholder="Numer umowy" required tabindex="3">
             <label for="nowy_umowa">Numer umowy:</label>
           </div>
+          <!-- List of participants moved to dedicated page -->
           <div class="form-floating mb-3">
-            <textarea class="form-control" id="nowi_uczestnicy" name="nowi_uczestnicy" placeholder="Uczestnicy" style="height: 7rem" required tabindex="4"></textarea>
-            <label for="nowi_uczestnicy">Uczestnicy (po jednym na linię):</label>
-          </div>
-          <div class="form-floating mb-3">
-            <input class="form-control" type="file" name="nowy_podpis" id="nowy_podpis" accept=".png,.jpg,.jpeg" tabindex="5">
+            <input class="form-control" type="file" name="nowy_podpis" id="nowy_podpis" accept=".png,.jpg,.jpeg" tabindex="4">
             <label for="nowy_podpis">Plik podpisu (.png lub .jpg):</label>
           </div>
         </div>
         <div class="modal-footer">
-          <button type="submit" class="btn btn-success" tabindex="6">Zapisz prowadzącego</button>
+          <button type="submit" class="btn btn-success" tabindex="5">Zapisz prowadzącego</button>
         </div>
       </form>
     </div>

--- a/templates/_trainer_modal_script.html
+++ b/templates/_trainer_modal_script.html
@@ -1,10 +1,9 @@
 <script>
-  function edytujProwadzacego(id, imie, nazwisko, umowa, uczestnicy) {
+  function edytujProwadzacego(id, imie, nazwisko, umowa) {
     document.getElementById('edit_id').value = id;
     document.getElementById('nowy_imie').value = imie;
     document.getElementById('nowy_nazwisko').value = nazwisko;
     document.getElementById('nowy_umowa').value = umowa;
-    document.getElementById('nowi_uczestnicy').value = uczestnicy.join('\n');
     const modal = bootstrap.Modal.getOrCreateInstance(document.getElementById('dodajModal'));
     modal.show();
   }

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -67,10 +67,14 @@
         </td>
         <td>{{ p.uczestnicy|length }}</td>
         <td class="text-nowrap">
-          <button class="btn btn-sm" onclick="edytujProwadzacego({{ p.id }}, '{{ p.imie }}', '{{ p.nazwisko }}', '{{ p.numer_umowy }}', [{% for u in p.uczestnicy %}'{{ u.imie_nazwisko }}'{% if not loop.last %}, {% endif %}{% endfor %}])" aria-label="Edytuj prowadzącego">
+          <button class="btn btn-sm" onclick="edytujProwadzacego({{ p.id }}, '{{ p.imie }}', '{{ p.nazwisko }}', '{{ p.numer_umowy }}')" aria-label="Edytuj prowadzącego">
             <i class="bi bi-pencil"></i>
             <span class="visually-hidden">Edytuj prowadzącego</span>
           </button>
+          <a href="{{ url_for('routes.admin_trainer', id=p.id) }}" class="btn btn-sm text-secondary" aria-label="Uczestnicy">
+            <i class="bi bi-people"></i>
+            <span class="visually-hidden">Uczestnicy</span>
+          </a>
           <form action="{{ url_for('routes.usun_prowadzacego', id=p.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć?')">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń prowadzącego">

--- a/templates/admin_trainer.html
+++ b/templates/admin_trainer.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+{% block title %}Uczestnicy{% endblock %}
+{% block content %}
+  <div aria-live="polite" role="status">
+    {% with messages = get_flashed_messages(with_categories=True) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+  </div>
+
+  <h2 class="mb-4">Uczestnicy prowadzącego {{ prowadzacy.imie }} {{ prowadzacy.nazwisko }}</h2>
+  <form method="POST" action="{{ url_for('routes.admin_add_participant', id=prowadzacy.id) }}" class="mb-3 d-flex">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <input type="text" class="form-control me-2" name="new_participant" placeholder="Imię i nazwisko">
+      <button type="submit" class="btn btn-primary">Dodaj</button>
+  </form>
+
+  <ul class="list-group mb-3">
+    {% for u in uczestnicy %}
+    <li class="list-group-item">
+      <div class="d-flex align-items-center justify-content-between">
+        <form action="{{ url_for('routes.admin_rename_participant', id=u.id) }}" method="post" class="d-flex align-items-center flex-grow-1 me-2">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <input type="text" name="new_name" value="{{ u.imie_nazwisko }}" class="form-control form-control-sm me-2">
+          <span class="me-2">{{ stats[u.id].present }}/{{ total_sessions }} ({{ '%.0f'|format(stats[u.id].percent) }}%)</span>
+          <button type="submit" class="btn btn-sm text-secondary" aria-label="Zapisz">
+            <i class="bi bi-check"></i>
+          </button>
+        </form>
+        <form action="{{ url_for('routes.admin_delete_participant', id=u.id) }}" method="post" class="ms-2">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń">
+            <i class="bi bi-x"></i>
+          </button>
+        </form>
+      </div>
+    </li>
+    {% endfor %}
+  </ul>
+
+  <a href="{{ url_for('routes.admin_dashboard') }}" class="btn btn-secondary">Powrót</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create a dedicated trainer page for participant management
- show participant add/rename/delete forms on that page
- remove participant textarea from trainer modal
- redirect to new page after saving trainer
- provide admin routes for participant CRUD
- add unit tests for admin participant management

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68481f249a3c832a9039b8411f38fc65