### PR TITLE
Add admin statistics page

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -75,6 +75,10 @@
             <i class="bi bi-people"></i>
             <span class="visually-hidden">Uczestnicy</span>
           </a>
+          <a href="{{ url_for('routes.admin_statystyki', trainer_id=p.id) }}" class="btn btn-sm text-info" aria-label="Statystyki">
+            <i class="bi bi-bar-chart"></i>
+            <span class="visually-hidden">Statystyki</span>
+          </a>
           <form action="{{ url_for('routes.usun_prowadzacego', id=p.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć?')">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń prowadzącego">

--- a/templates/admin_statystyki.html
+++ b/templates/admin_statystyki.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block title %}Statystyki{% endblock %}
+{% block content %}
+  <h2 class="mb-4">Statystyki obecności - {{ prowadzacy.imie }} {{ prowadzacy.nazwisko }}</h2>
+  <table class="table table-striped table-hover mb-4">
+    <thead class="table-secondary">
+      <tr>
+        <th>Uczestnik</th>
+        <th>Obecności</th>
+        <th>Frekwencja</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in stats %}
+      <tr>
+        <td>{{ row.uczestnik.imie_nazwisko }}</td>
+        <td>{{ row.present }}/{{ total_sessions }}</td>
+        <td>{{ '%.0f'|format(row.percent) }}%</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <a href="{{ url_for('routes.admin_dashboard') }}" class="btn btn-secondary">Powrót</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow admins to view attendance statistics for a specific trainer
- add new template for admin statistics
- link to statistics from trainer list in admin dashboard
- test admin statistics page access control

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848212d2ddc832ab83bb3d249e52c54