### PR TITLE
Add sent column

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -155,6 +155,7 @@
         <th>Prowadzący</th>
         <th>Obecni</th>
         <th>Akcja</th>
+        <th>Wysłano</th>
       </tr>
     </thead>
     <tbody>
@@ -184,6 +185,8 @@
               <span class="visually-hidden">Usuń zajęcia</span>
             </button>
           </form>
+        </td>
+        <td>
           {% if z.wyslano %}
           <i class="bi bi-check-lg text-success"></i>
           {% endif %}

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -115,6 +115,7 @@
         <th>Czas</th>
         <th>Obecni</th>
         <th>Akcja</th>
+        <th>Wysłano</th>
       </tr>
     </thead>
     <tbody>
@@ -143,6 +144,8 @@
               <span class="visually-hidden">Usuń zajęcia</span>
             </button>
           </form>
+        </td>
+        <td>
           {% if z.wyslano %}
           <i class="bi bi-check-lg text-success"></i>
           {% endif %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -416,6 +416,12 @@ def test_wyslij_zajecie_success(client, app, monkeypatch):
     with app.app_context():
         assert db.session.get(Zajecia, zaj_id).wyslano is True
 
+    # Check that the session row shows the sent indicator
+    resp = client.get("/panel")
+    assert resp.status_code == 200
+    data = resp.data.decode()
+    assert "bi bi-check-lg text-success" in data
+
 
 def test_wyslij_zajecie_admin_requires_login(client):
     resp = client.get("/wyslij_zajecie_admin/1")
@@ -461,6 +467,11 @@ def test_wyslij_zajecie_admin_success(client, app, monkeypatch):
     assert called.get("sent")
     with app.app_context():
         assert db.session.get(Zajecia, zaj_id).wyslano is True
+
+    resp = client.get("/admin")
+    assert resp.status_code == 200
+    data = resp.data.decode()
+    assert "bi bi-check-lg text-success" in data
 
 
 def test_wyslij_zajecie_admin_requires_admin(client, app):


### PR DESCRIPTION
## Summary
- show sent state in history tables
- adjust tests for new markup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848229f0a50832a96a94edc08a8750a