### PR TITLE
Improve participant list view with edit mode

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -279,6 +279,7 @@ def admin_trainer(id):
         present = sum(1 for z in u.zajecia if z.prowadzacy_id == prow.id)
         percent = (present / total_sessions * 100) if total_sessions else 0
         stats[u.id] = {"present": present, "percent": percent}
+    edit_mode = request.args.get("edit") == "1"
 
     return render_template(
         "admin_trainer.html",
@@ -286,6 +287,7 @@ def admin_trainer(id):
         uczestnicy=uczestnicy,
         stats=stats,
         total_sessions=total_sessions,
+        edit_mode=edit_mode,
     )
 
 
@@ -303,7 +305,8 @@ def admin_add_participant(id):
         flash("Uczestnik dodany", "success")
     else:
         flash("Brak nazwy uczestnika", "danger")
-    return redirect(url_for("routes.admin_trainer", id=id))
+    edit = request.args.get("edit") == "1"
+    return redirect(url_for("routes.admin_trainer", id=id, edit="1" if edit else None))
 
 
 @routes_bp.route("/admin/participant/<int:id>/rename", methods=["POST"])
@@ -320,7 +323,8 @@ def admin_rename_participant(id):
         flash("Uczestnik zaktualizowany", "success")
     else:
         flash("Brak nazwy uczestnika", "danger")
-    return redirect(url_for("routes.admin_trainer", id=uczestnik.prowadzacy_id))
+    edit = request.args.get("edit") == "1"
+    return redirect(url_for("routes.admin_trainer", id=uczestnik.prowadzacy_id, edit="1" if edit else None))
 
 
 @routes_bp.route("/admin/participant/<int:id>/delete", methods=["POST"])
@@ -333,7 +337,8 @@ def admin_delete_participant(id):
     db.session.delete(uczestnik)
     db.session.commit()
     flash("Uczestnik usunięty", "info")
-    return redirect(url_for("routes.admin_trainer", id=pid))
+    edit = request.args.get("edit") == "1"
+    return redirect(url_for("routes.admin_trainer", id=pid, edit="1" if edit else None))
 
 
 @routes_bp.route("/approve_user/<int:id>", methods=["POST", "GET"])

--- a/routes/panel.py
+++ b/routes/panel.py
@@ -30,6 +30,7 @@ def panel():
         abort(404)
 
     uczestnicy, all_zajecia, stats, total_sessions = get_participant_stats(prow)
+    edit_mode = request.args.get("edit") == "1"
     page = request.args.get("page", 1, type=int)
     pagination = (
         Zajecia.query.filter_by(prowadzacy_id=prow.id)
@@ -55,6 +56,7 @@ def panel():
         podsumowanie=podsumowanie,
         stats=stats,
         total_sessions=total_sessions,
+        edit_mode=edit_mode,
     )
 
 
@@ -120,7 +122,8 @@ def dodaj_uczestnika():
     else:
         flash("Brak nazwy uczestnika", "danger")
 
-    return redirect(url_for("routes.panel"))
+    edit = request.args.get("edit") == "1"
+    return redirect(url_for("routes.panel", edit="1" if edit else None))
 
 
 @routes_bp.route("/panel/zmien_uczestnika/<int:id>", methods=["POST"])
@@ -140,7 +143,8 @@ def zmien_uczestnika(id):
     else:
         flash("Brak nazwy uczestnika", "danger")
 
-    return redirect(url_for("routes.panel"))
+    edit = request.args.get("edit") == "1"
+    return redirect(url_for("routes.panel", edit="1" if edit else None))
 
 
 @routes_bp.route("/usun_uczestnika/<int:id>", methods=["POST"])
@@ -155,7 +159,8 @@ def usun_uczestnika(id):
     db.session.delete(uczestnik)
     db.session.commit()
     flash("Uczestnik usunięty", "info")
-    return redirect(url_for("routes.panel"))
+    edit = request.args.get("edit") == "1"
+    return redirect(url_for("routes.panel", edit="1" if edit else None))
 
 
 @routes_bp.route("/pobierz_zajecie/<int:id>")

--- a/templates/admin_trainer.html
+++ b/templates/admin_trainer.html
@@ -11,35 +11,60 @@
     {% endwith %}
   </div>
 
-  <h2 class="mb-4">Uczestnicy prowadzącego {{ prowadzacy.imie }} {{ prowadzacy.nazwisko }}</h2>
-  <form method="POST" action="{{ url_for('routes.admin_add_participant', id=prowadzacy.id) }}" class="mb-3 d-flex">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <input type="text" class="form-control me-2" name="new_participant" placeholder="Imię i nazwisko">
-      <button type="submit" class="btn btn-primary">Dodaj</button>
-  </form>
+  {% if edit_mode %}
+    <h2 class="mb-4">Uczestnicy prowadzącego {{ prowadzacy.imie }} {{ prowadzacy.nazwisko }}</h2>
+    <form method="POST" action="{{ url_for('routes.admin_add_participant', id=prowadzacy.id) }}?edit=1" class="mb-3 d-flex">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <input type="text" class="form-control me-2" name="new_participant" placeholder="Imię i nazwisko">
+        <button type="submit" class="btn btn-primary">Dodaj</button>
+    </form>
 
-  <ul class="list-group mb-3">
-    {% for u in uczestnicy %}
-    <li class="list-group-item">
-      <div class="d-flex align-items-center justify-content-between">
-        <form action="{{ url_for('routes.admin_rename_participant', id=u.id) }}" method="post" class="d-flex align-items-center flex-grow-1 me-2">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-          <input type="text" name="new_name" value="{{ u.imie_nazwisko }}" class="form-control form-control-sm me-2">
-          <span class="me-2">{{ stats[u.id].present }}/{{ total_sessions }} ({{ '%.0f'|format(stats[u.id].percent) }}%)</span>
-          <button type="submit" class="btn btn-sm text-secondary" aria-label="Zapisz">
-            <i class="bi bi-check"></i>
-          </button>
-        </form>
-        <form action="{{ url_for('routes.admin_delete_participant', id=u.id) }}" method="post" class="ms-2">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-          <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń">
-            <i class="bi bi-x"></i>
-          </button>
-        </form>
-      </div>
-    </li>
-    {% endfor %}
-  </ul>
+    <ul class="list-group mb-3">
+      {% for u in uczestnicy %}
+      <li class="list-group-item">
+        <div class="d-flex align-items-center justify-content-between">
+          <form action="{{ url_for('routes.admin_rename_participant', id=u.id) }}?edit=1" method="post" class="d-flex align-items-center flex-grow-1 me-2">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <input type="text" name="new_name" value="{{ u.imie_nazwisko }}" class="form-control form-control-sm me-2">
+            <button type="submit" class="btn btn-sm text-secondary" aria-label="Zapisz">
+              <i class="bi bi-check"></i>
+            </button>
+          </form>
+          <form action="{{ url_for('routes.admin_delete_participant', id=u.id) }}?edit=1" method="post" class="ms-2">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń">
+              <i class="bi bi-x"></i>
+            </button>
+          </form>
+        </div>
+      </li>
+      {% endfor %}
+    </ul>
 
-  <a href="{{ url_for('routes.admin_dashboard') }}" class="btn btn-secondary">Powrót</a>
+    <a href="{{ url_for('routes.admin_trainer', id=prowadzacy.id) }}" class="btn btn-secondary">Zakończ edycję</a>
+
+  {% else %}
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h2 class="mb-0">Uczestnicy prowadzącego {{ prowadzacy.imie }} {{ prowadzacy.nazwisko }}</h2>
+      <a href="{{ url_for('routes.admin_trainer', id=prowadzacy.id, edit=1) }}" class="btn btn-outline-primary">Edytuj</a>
+    </div>
+
+    <ul class="list-group mb-3">
+      {% for u in uczestnicy %}
+      <li class="list-group-item">
+        <div class="d-flex align-items-center justify-content-between">
+          <span class="flex-grow-1">{{ u.imie_nazwisko }}</span>
+          <div class="d-flex align-items-center ms-3" style="min-width: 180px;">
+            <div class="progress flex-grow-1 me-2" style="height: 6px;">
+              <div class="progress-bar" role="progressbar" style="width: {{ stats[u.id].percent }}%" aria-valuenow="{{ stats[u.id].percent }}" aria-valuemin="0" aria-valuemax="100"></div>
+            </div>
+            <small class="text-nowrap">{{ '%.0f'|format(stats[u.id].percent) }}% {{ stats[u.id].present }}/{{ total_sessions }}</small>
+          </div>
+        </div>
+      </li>
+      {% endfor %}
+    </ul>
+
+    <a href="{{ url_for('routes.admin_dashboard') }}" class="btn btn-secondary">Powrót</a>
+  {% endif %}
 {% endblock %}

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -48,35 +48,58 @@
     </div>
   </form>
 
-  <h2 class="mb-4">Uczestnicy</h2>
-  <form method="POST" action="{{ url_for('routes.dodaj_uczestnika') }}" class="mb-3 d-flex">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <input type="text" class="form-control me-2" name="new_participant" placeholder="Imię i nazwisko">
-      <button type="submit" class="btn btn-primary">Dodaj</button>
-  </form>
+  {% if edit_mode %}
+    <h2 class="mb-4">Uczestnicy</h2>
+    <form method="POST" action="{{ url_for('routes.dodaj_uczestnika') }}?edit=1" class="mb-3 d-flex">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <input type="text" class="form-control me-2" name="new_participant" placeholder="Imię i nazwisko">
+        <button type="submit" class="btn btn-primary">Dodaj</button>
+    </form>
 
-  <ul class="list-group mb-3">
-    {% for u in uczestnicy %}
-    <li class="list-group-item">
-      <div class="d-flex align-items-center justify-content-between">
-        <form action="{{ url_for('routes.zmien_uczestnika', id=u.id) }}" method="post" class="d-flex align-items-center flex-grow-1 me-2">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-          <input type="text" name="new_name" value="{{ u.imie_nazwisko }}" class="form-control form-control-sm me-2">
-          <span class="me-2">{{ stats[u.id].present }}/{{ total_sessions }} ({{ '%.0f'|format(stats[u.id].percent) }}%)</span>
-          <button type="submit" class="btn btn-sm text-secondary" aria-label="Zapisz">
-            <i class="bi bi-check"></i>
-          </button>
-        </form>
-        <form action="{{ url_for('routes.usun_uczestnika', id=u.id) }}" method="post" class="ms-2">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-          <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń">
-            <i class="bi bi-x"></i>
-          </button>
-        </form>
-      </div>
-    </li>
-    {% endfor %}
-  </ul>
+    <ul class="list-group mb-3">
+      {% for u in uczestnicy %}
+      <li class="list-group-item">
+        <div class="d-flex align-items-center justify-content-between">
+          <form action="{{ url_for('routes.zmien_uczestnika', id=u.id) }}?edit=1" method="post" class="d-flex align-items-center flex-grow-1 me-2">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <input type="text" name="new_name" value="{{ u.imie_nazwisko }}" class="form-control form-control-sm me-2">
+            <button type="submit" class="btn btn-sm text-secondary" aria-label="Zapisz">
+              <i class="bi bi-check"></i>
+            </button>
+          </form>
+          <form action="{{ url_for('routes.usun_uczestnika', id=u.id) }}?edit=1" method="post" class="ms-2">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń">
+              <i class="bi bi-x"></i>
+            </button>
+          </form>
+        </div>
+      </li>
+      {% endfor %}
+    </ul>
+    <a href="{{ url_for('routes.panel') }}" class="btn btn-secondary">Zakończ edycję</a>
+  {% else %}
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h2 class="mb-0">Uczestnicy</h2>
+      <a href="{{ url_for('routes.panel', edit=1) }}" class="btn btn-outline-primary">Edytuj</a>
+    </div>
+
+    <ul class="list-group mb-3">
+      {% for u in uczestnicy %}
+      <li class="list-group-item">
+        <div class="d-flex align-items-center justify-content-between">
+          <span class="flex-grow-1">{{ u.imie_nazwisko }}</span>
+          <div class="d-flex align-items-center ms-3" style="min-width: 180px;">
+            <div class="progress flex-grow-1 me-2" style="height: 6px;">
+              <div class="progress-bar" role="progressbar" style="width: {{ stats[u.id].percent }}%" aria-valuenow="{{ stats[u.id].percent }}" aria-valuemin="0" aria-valuemax="100"></div>
+            </div>
+            <small class="text-nowrap">{{ '%.0f'|format(stats[u.id].percent) }}% {{ stats[u.id].present }}/{{ total_sessions }}</small>
+          </div>
+        </div>
+      </li>
+      {% endfor %}
+    </ul>
+  {% endif %}
 
   <p>
     <a href="{{ url_for('routes.panel_statystyki') }}" class="btn btn-outline-secondary">Statystyki obecności</a>


### PR DESCRIPTION
## Summary
- add `edit` mode when viewing trainer participants
- show progress bars with attendance on participant list
- hide statistics while editing
- keep edit mode active when adding/removing participants

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483e0ee218832aac043aa7889adb4b