### PR TITLE
Add tooltips to action icons

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -67,26 +67,26 @@
         </td>
         <td>{{ p.uczestnicy|length }}</td>
         <td class="text-nowrap">
-          <button class="btn btn-sm" onclick="edytujProwadzacego({{ p.id }}, '{{ p.imie }}', '{{ p.nazwisko }}', '{{ p.numer_umowy }}')" aria-label="Edytuj prowadzącego">
+          <button class="btn btn-sm" onclick="edytujProwadzacego({{ p.id }}, '{{ p.imie }}', '{{ p.nazwisko }}', '{{ p.numer_umowy }}')" aria-label="Edytuj prowadzącego" title="Edytuj prowadzącego">
             <i class="bi bi-pencil"></i>
             <span class="visually-hidden">Edytuj prowadzącego</span>
           </button>
-          <a href="{{ url_for('routes.admin_trainer', id=p.id) }}" class="btn btn-sm text-secondary" aria-label="Uczestnicy">
+          <a href="{{ url_for('routes.admin_trainer', id=p.id) }}" class="btn btn-sm text-secondary" aria-label="Uczestnicy" title="Uczestnicy">
             <i class="bi bi-people"></i>
             <span class="visually-hidden">Uczestnicy</span>
           </a>
-          <a href="{{ url_for('routes.admin_statystyki', trainer_id=p.id) }}" class="btn btn-sm text-info" aria-label="Statystyki">
+          <a href="{{ url_for('routes.admin_statystyki', trainer_id=p.id) }}" class="btn btn-sm text-info" aria-label="Statystyki" title="Statystyki">
             <i class="bi bi-bar-chart"></i>
             <span class="visually-hidden">Statystyki</span>
           </a>
           <form action="{{ url_for('routes.usun_prowadzacego', id=p.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć?')">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń prowadzącego">
+            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń prowadzącego" title="Usuń prowadzącego">
               <i class="bi bi-trash"></i>
               <span class="visually-hidden">Usuń prowadzącego</span>
             </button>
           </form>
-          <button class="btn btn-sm text-primary" data-bs-toggle="modal" data-bs-target="#raportModal{{ p.id }}" aria-label="Raport miesięczny">
+          <button class="btn btn-sm text-primary" data-bs-toggle="modal" data-bs-target="#raportModal{{ p.id }}" aria-label="Raport miesięczny" title="Raport miesięczny">
             <i class="bi bi-file-earmark-text"></i>
             <span class="visually-hidden">Raport miesięczny</span>
           </button>
@@ -166,21 +166,21 @@
         <td>{{ z.prowadzacy.imie }} {{ z.prowadzacy.nazwisko }}</td>
         <td>{{ z.obecni|length }}/{{ z.prowadzacy.uczestnicy|length }}</td>
         <td class="text-nowrap">
-          <a href="{{ url_for('routes.edytuj_zajecie', id=z.id) }}" class="btn btn-sm" aria-label="Edytuj zajęcia">
+          <a href="{{ url_for('routes.edytuj_zajecie', id=z.id) }}" class="btn btn-sm" aria-label="Edytuj zajęcia" title="Edytuj zajęcia">
             <i class="bi bi-pencil"></i>
             <span class="visually-hidden">Edytuj zajęcia</span>
           </a>
-          <a href="{{ url_for('routes.pobierz_zajecie_admin', id=z.id) }}" class="btn btn-sm text-primary" aria-label="Pobierz dokument">
+          <a href="{{ url_for('routes.pobierz_zajecie_admin', id=z.id) }}" class="btn btn-sm text-primary" aria-label="Pobierz dokument" title="Pobierz dokument">
             <i class="bi bi-download"></i>
             <span class="visually-hidden">Pobierz dokument</span>
           </a>
-          <a href="{{ url_for('routes.wyslij_zajecie_admin', id=z.id) }}" class="btn btn-sm text-secondary" aria-label="Wyślij dokument mailem">
+          <a href="{{ url_for('routes.wyslij_zajecie_admin', id=z.id) }}" class="btn btn-sm text-secondary" aria-label="Wyślij dokument mailem" title="Wyślij dokument mailem">
             <i class="bi bi-envelope"></i>
             <span class="visually-hidden">Wyślij dokument mailem</span>
           </a>
           <form action="{{ url_for('routes.usun_zajecie', id=z.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Na pewno usunąć zajęcia?')">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń zajęcia">
+            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń zajęcia" title="Usuń zajęcia">
               <i class="bi bi-trash"></i>
               <span class="visually-hidden">Usuń zajęcia</span>
             </button>

--- a/templates/admin_trainer.html
+++ b/templates/admin_trainer.html
@@ -26,13 +26,13 @@
           <form action="{{ url_for('routes.admin_rename_participant', id=u.id) }}?edit=1" method="post" class="d-flex align-items-center flex-grow-1 me-2">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="text" name="new_name" value="{{ u.imie_nazwisko }}" class="form-control form-control-sm me-2">
-            <button type="submit" class="btn btn-sm text-secondary" aria-label="Zapisz">
+            <button type="submit" class="btn btn-sm text-secondary" aria-label="Zapisz" title="Zapisz">
               <i class="bi bi-check"></i>
             </button>
           </form>
           <form action="{{ url_for('routes.admin_delete_participant', id=u.id) }}?edit=1" method="post" class="ms-2">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń">
+            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń" title="Usuń">
               <i class="bi bi-x"></i>
             </button>
           </form>

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,7 +20,7 @@
         <a href="{{ url_for('routes.index') }}" class="btn btn-outline-light">Powrót</a>
         {% if is_admin %}
         <a href="{{ url_for('routes.admin_dashboard') }}" class="btn btn-outline-light">Panel administratora</a>
-        <a href="{{ url_for('routes.admin_settings') }}" class="btn btn-outline-light" aria-label="Ustawienia"><i class="bi bi-gear"></i></a>
+        <a href="{{ url_for('routes.admin_settings') }}" class="btn btn-outline-light" aria-label="Ustawienia" title="Ustawienia"><i class="bi bi-gear"></i></a>
         {% elif current_user.is_authenticated %}
         <a href="{{ url_for('routes.panel') }}" class="btn btn-outline-light">{% if current_user.role == 'prowadzacy' %}Panel prowadzącego{% else %}Panel{% endif %}</a>
         {% endif %}
@@ -28,8 +28,8 @@
         {% if current_user.is_authenticated %}
         <a href="{{ url_for('routes.logout') }}" class="btn btn-outline-danger">Wyloguj</a>
         {% endif %}
-        <button class="btn btn-outline-light" id="darkModeToggle" aria-label="Tryb ciemny"><i class="bi bi-moon"></i></button>
-        <button class="btn btn-outline-light" id="contrastToggle" aria-label="Wysoki kontrast"><i class="bi bi-circle-half"></i></button>
+        <button class="btn btn-outline-light" id="darkModeToggle" aria-label="Tryb ciemny" title="Tryb ciemny"><i class="bi bi-moon"></i></button>
+        <button class="btn btn-outline-light" id="contrastToggle" aria-label="Wysoki kontrast" title="Wysoki kontrast"><i class="bi bi-circle-half"></i></button>
       </div>
     </div>
   </nav>

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,7 +38,7 @@
           {% endfor %}
         </select>
       </div>
-      <button type="button" class="btn btn-outline-success ms-3" style="white-space: nowrap;" data-bs-toggle="modal" data-bs-target="#dodajModal" aria-label="Dodaj prowadzącego">
+      <button type="button" class="btn btn-outline-success ms-3" style="white-space: nowrap;" data-bs-toggle="modal" data-bs-target="#dodajModal" aria-label="Dodaj prowadzącego" title="Dodaj prowadzącego">
         <i class="bi bi-person-plus"></i>
         <span class="visually-hidden">Dodaj prowadzącego</span>
       </button>

--- a/templates/login.html
+++ b/templates/login.html
@@ -25,7 +25,7 @@
       <div class="form-floating mb-3 position-relative">
         <input type="password" class="form-control" id="hasło" name="hasło" placeholder="Hasło" required autocomplete="current-password" tabindex="2">
         <label for="hasło">Hasło:</label>
-        <button type="button" class="btn btn-outline-secondary border-0 position-absolute top-50 end-0 translate-middle-y" onclick="togglePassword('hasło', this)" tabindex="-1" aria-label="Pokaż lub ukryj hasło">
+        <button type="button" class="btn btn-outline-secondary border-0 position-absolute top-50 end-0 translate-middle-y" onclick="togglePassword('hasło', this)" tabindex="-1" aria-label="Pokaż lub ukryj hasło" title="Pokaż lub ukryj hasło">
           <i class="bi bi-eye"></i>
         </button>
       </div>

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -63,13 +63,13 @@
           <form action="{{ url_for('routes.zmien_uczestnika', id=u.id) }}?edit=1" method="post" class="d-flex align-items-center flex-grow-1 me-2">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="text" name="new_name" value="{{ u.imie_nazwisko }}" class="form-control form-control-sm me-2">
-            <button type="submit" class="btn btn-sm text-secondary" aria-label="Zapisz">
+            <button type="submit" class="btn btn-sm text-secondary" aria-label="Zapisz" title="Zapisz">
               <i class="bi bi-check"></i>
             </button>
           </form>
           <form action="{{ url_for('routes.usun_uczestnika', id=u.id) }}?edit=1" method="post" class="ms-2">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń">
+            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń" title="Usuń">
               <i class="bi bi-x"></i>
             </button>
           </form>
@@ -156,21 +156,21 @@
         <td>{{ z.czas_trwania }}</td>
         <td>{{ z.obecni|length }}/{{ z.prowadzacy.uczestnicy|length }}</td>
         <td class="text-nowrap">
-          <a href="{{ url_for('routes.panel_edytuj_zajecie', id=z.id) }}" class="btn btn-sm" aria-label="Edytuj zajęcia">
+          <a href="{{ url_for('routes.panel_edytuj_zajecie', id=z.id) }}" class="btn btn-sm" aria-label="Edytuj zajęcia" title="Edytuj zajęcia">
             <i class="bi bi-pencil"></i>
             <span class="visually-hidden">Edytuj zajęcia</span>
           </a>
-          <a href="{{ url_for('routes.pobierz_zajecie', id=z.id) }}" class="btn btn-sm text-primary" aria-label="Pobierz dokument">
+          <a href="{{ url_for('routes.pobierz_zajecie', id=z.id) }}" class="btn btn-sm text-primary" aria-label="Pobierz dokument" title="Pobierz dokument">
             <i class="bi bi-download"></i>
             <span class="visually-hidden">Pobierz dokument</span>
           </a>
-          <a href="{{ url_for('routes.wyslij_zajecie', id=z.id) }}" class="btn btn-sm text-secondary" aria-label="Wyślij dokument mailem">
+          <a href="{{ url_for('routes.wyslij_zajecie', id=z.id) }}" class="btn btn-sm text-secondary" aria-label="Wyślij dokument mailem" title="Wyślij dokument mailem">
             <i class="bi bi-envelope"></i>
             <span class="visually-hidden">Wyślij dokument mailem</span>
           </a>
           <form action="{{ url_for('routes.usun_moje_zajecie', id=z.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Usunąć zajęcia?')">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń zajęcia">
+            <button type="submit" class="btn btn-sm text-danger" aria-label="Usuń zajęcia" title="Usuń zajęcia">
               <i class="bi bi-trash"></i>
               <span class="visually-hidden">Usuń zajęcia</span>
             </button>

--- a/templates/register.html
+++ b/templates/register.html
@@ -28,7 +28,7 @@
       <div class="form-floating mb-3 position-relative">
         <input type="password" class="form-control" id="haslo" name="haslo" placeholder="Hasło" required autocomplete="new-password" tabindex="6">
         <label for="haslo">Hasło:</label>
-        <button type="button" class="btn btn-outline-secondary border-0 position-absolute top-50 end-0 translate-middle-y" onclick="togglePassword('haslo', this)" tabindex="-1" aria-label="Pokaż lub ukryj hasło">
+        <button type="button" class="btn btn-outline-secondary border-0 position-absolute top-50 end-0 translate-middle-y" onclick="togglePassword('haslo', this)" tabindex="-1" aria-label="Pokaż lub ukryj hasło" title="Pokaż lub ukryj hasło">
           <i class="bi bi-eye"></i>
         </button>
       </div>


### PR DESCRIPTION
## Summary
- add `title` attributes to icon-only action buttons so they show tooltips

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848459f2818832a9a6134f6a77b86d8