### PR TITLE
Improve history filter UX

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -134,17 +134,17 @@
         <label for="p_id" class="form-label">Prowadzący:</label>
       </div>
       <div class="col-auto">
-        <select name="p_id" id="p_id" class="form-select">
+        <select name="p_id" id="p_id" class="form-select" onchange="this.form.submit()">
           <option value="" {% if not selected_p_id %}selected{% endif %}>Wszyscy</option>
           {% for p in prowadzacy %}
           <option value="{{ p.id }}" {% if selected_p_id and p.id == selected_p_id %}selected{% endif %}>{{ p.imie }} {{ p.nazwisko }}</option>
           {% endfor %}
         </select>
       </div>
-      <div class="col-auto">
-        <button type="submit" class="btn btn-primary">Filtruj</button>
-      </div>
     </div>
+    <noscript>
+      <div class="text-danger small mt-2">Włącz obsługę JavaScript, aby filtrować wyniki.</div>
+    </noscript>
   </form>
 
   <table class="table table-striped table-hover">


### PR DESCRIPTION
## Summary
- auto-submit history filter when trainer is selected
- add a noscript warning for browsers without JavaScript

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684847f52468832aa8285ade61b363c4