### PR TITLE
Switch monthly report actions to icons

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -21,7 +21,10 @@
         <td>
           <form action="{{ url_for('routes.approve_user', id=u.id) }}" method="POST" class="d-inline">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="btn btn-sm btn-success">Akceptuj</button>
+            <button type="submit" class="btn btn-sm btn-success" aria-label="Akceptuj" title="Akceptuj">
+              <i class="bi bi-check"></i>
+              <span class="visually-hidden">Akceptuj</span>
+            </button>
           </form>
         </td>
       </tr>
@@ -113,8 +116,14 @@
                 </div>
               </div>
               <div class="modal-footer">
-                <button type="submit" class="btn btn-primary" tabindex="3">Pobierz</button>
-                <button type="submit" name="wyslij" value="1" class="btn btn-outline-secondary" tabindex="4">Wyślij mailem</button>
+                <button type="submit" class="btn btn-primary" tabindex="3" aria-label="Pobierz" title="Pobierz">
+                  <i class="bi bi-download"></i>
+                  <span class="visually-hidden">Pobierz</span>
+                </button>
+                <button type="submit" name="wyslij" value="1" class="btn btn-outline-secondary" tabindex="4" aria-label="Wyślij mailem" title="Wyślij mailem">
+                  <i class="bi bi-envelope"></i>
+                  <span class="visually-hidden">Wyślij mailem</span>
+                </button>
               </div>
             </form>
           </div>

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -130,8 +130,14 @@
         <td>{{ '%02d'|format(miesiac) }}</td>
         <td>{{ godziny }}</td>
         <td class="text-nowrap">
-          <a href="{{ url_for('routes.panel_raport') }}?rok={{ rok }}&miesiac={{ miesiac }}" class="btn btn-sm text-primary">Pobierz</a>
-          <a href="{{ url_for('routes.panel_raport') }}?rok={{ rok }}&miesiac={{ miesiac }}&wyslij=1" class="btn btn-sm text-secondary">Wyślij</a>
+          <a href="{{ url_for('routes.panel_raport') }}?rok={{ rok }}&miesiac={{ miesiac }}" class="btn btn-sm text-primary" aria-label="Pobierz" title="Pobierz">
+            <i class="bi bi-download"></i>
+            <span class="visually-hidden">Pobierz</span>
+          </a>
+          <a href="{{ url_for('routes.panel_raport') }}?rok={{ rok }}&miesiac={{ miesiac }}&wyslij=1" class="btn btn-sm text-secondary" aria-label="Wyślij" title="Wyślij">
+            <i class="bi bi-envelope"></i>
+            <span class="visually-hidden">Wyślij</span>
+          </a>
         </td>
       </tr>
       {% endfor %}


### PR DESCRIPTION
## Summary
- use a bi-check icon for approving user accounts
- swap modal report actions for icon buttons
- change monthly report table actions to icon buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68484da2268c832ab92e590756ed376c