### PR TITLE
Remove broken stat link

### DIFF
--- a/templates/panel.html
+++ b/templates/panel.html
@@ -109,9 +109,6 @@
     </ul>
   {% endif %}
 
-  <p>
-    <a href="{{ url_for('routes.panel_statystyki') }}" class="btn btn-outline-secondary">Statystyki obecności</a>
-  </p>
 
   <h2 class="mb-4">Raporty miesięczne</h2>
   <table class="table table-striped table-hover mb-5">


### PR DESCRIPTION
## Summary
- delete the 'Statystyki obecności' link from the trainer panel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68484f44d478832a9a98751099429d1a