### PR TITLE
Set consistent class for action columns

### DIFF
--- a/static/theme.css
+++ b/static/theme.css
@@ -25,3 +25,9 @@ body.high-contrast .btn {
   background-color: var(--bs-body-bg);
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.1);
 }
+
+/* Narrow column for action buttons */
+.action-col {
+  width: 1%;
+  white-space: nowrap;
+}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -9,7 +9,7 @@
         <th>ID</th>
         <th>Login</th>
         <th>Imię i nazwisko</th>
-        <th>Akcja</th>
+        <th class="action-col text-nowrap">Akcja</th>
       </tr>
     </thead>
     <tbody>
@@ -18,7 +18,7 @@
         <td>{{ u.id }}</td>
         <td>{{ u.login }}</td>
         <td>{{ u.prowadzacy.imie }} {{ u.prowadzacy.nazwisko }}</td>
-        <td>
+        <td class="action-col text-nowrap">
           <form action="{{ url_for('routes.approve_user', id=u.id) }}" method="POST" class="d-inline">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit" class="btn btn-sm btn-success" aria-label="Akceptuj" title="Akceptuj">
@@ -163,7 +163,7 @@
         <th>Czas trwania</th>
         <th>Prowadzący</th>
         <th>Obecni</th>
-        <th>Akcja</th>
+        <th class="action-col text-nowrap">Akcja</th>
         <th>Wysłano</th>
       </tr>
     </thead>
@@ -174,7 +174,7 @@
         <td>{{ z.czas_trwania }}</td>
         <td>{{ z.prowadzacy.imie }} {{ z.prowadzacy.nazwisko }}</td>
         <td>{{ z.obecni|length }}/{{ z.prowadzacy.uczestnicy|length }}</td>
-        <td class="text-nowrap">
+        <td class="action-col text-nowrap">
           <a href="{{ url_for('routes.edytuj_zajecie', id=z.id) }}" class="btn btn-sm" aria-label="Edytuj zajęcia" title="Edytuj zajęcia">
             <i class="bi bi-pencil"></i>
             <span class="visually-hidden">Edytuj zajęcia</span>

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -117,7 +117,7 @@
         <th>Rok</th>
         <th>Miesiąc</th>
         <th>Godzin</th>
-        <th>Akcja</th>
+        <th class="action-col text-nowrap">Akcja</th>
       </tr>
     </thead>
     <tbody>
@@ -126,7 +126,7 @@
         <td>{{ rok }}</td>
         <td>{{ '%02d'|format(miesiac) }}</td>
         <td>{{ godziny }}</td>
-        <td class="text-nowrap">
+        <td class="action-col text-nowrap">
           <a href="{{ url_for('routes.panel_raport') }}?rok={{ rok }}&miesiac={{ miesiac }}" class="btn btn-sm text-primary" aria-label="Pobierz" title="Pobierz">
             <i class="bi bi-download"></i>
             <span class="visually-hidden">Pobierz</span>
@@ -148,7 +148,7 @@
         <th>Data</th>
         <th>Czas</th>
         <th>Obecni</th>
-        <th>Akcja</th>
+        <th class="action-col text-nowrap">Akcja</th>
         <th>Wysłano</th>
       </tr>
     </thead>
@@ -158,7 +158,7 @@
         <td>{{ z.data.date() }}</td>
         <td>{{ z.czas_trwania }}</td>
         <td>{{ z.obecni|length }}/{{ z.prowadzacy.uczestnicy|length }}</td>
-        <td class="text-nowrap">
+        <td class="action-col text-nowrap">
           <a href="{{ url_for('routes.panel_edytuj_zajecie', id=z.id) }}" class="btn btn-sm" aria-label="Edytuj zajęcia" title="Edytuj zajęcia">
             <i class="bi bi-pencil"></i>
             <span class="visually-hidden">Edytuj zajęcia</span>


### PR DESCRIPTION
## Summary
- add `.action-col` CSS utility
- apply `action-col text-nowrap` to all "Akcja" header and data cells

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684850174a00832a9048c747174c45d4