### PR TITLE
Fix column order in history tables

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -159,17 +159,22 @@
   <table class="table table-striped table-hover">
     <thead class="table-secondary">
       <tr>
+        <th>Wysłano</th>
         <th>Data</th>
         <th>Czas trwania</th>
         <th>Prowadzący</th>
         <th>Obecni</th>
         <th class="action-col text-nowrap">Akcja</th>
-        <th>Wysłano</th>
       </tr>
     </thead>
     <tbody>
       {% for z in zajecia %}
       <tr>
+        <td>
+          {% if z.wyslano %}
+          <i class="bi bi-check-lg text-success"></i>
+          {% endif %}
+        </td>
         <td>{{ z.data.date() }}</td>
         <td>{{ z.czas_trwania }}</td>
         <td>{{ z.prowadzacy.imie }} {{ z.prowadzacy.nazwisko }}</td>
@@ -194,11 +199,6 @@
               <span class="visually-hidden">Usuń zajęcia</span>
             </button>
           </form>
-        </td>
-        <td>
-          {% if z.wyslano %}
-          <i class="bi bi-check-lg text-success"></i>
-          {% endif %}
         </td>
       </tr>
       {% endfor %}

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -145,16 +145,21 @@
   <table class="table table-striped table-hover">
     <thead class="table-secondary">
       <tr>
+        <th>Wysłano</th>
         <th>Data</th>
         <th>Czas</th>
         <th>Obecni</th>
         <th class="action-col text-nowrap">Akcja</th>
-        <th>Wysłano</th>
       </tr>
     </thead>
     <tbody>
       {% for z in zajecia %}
       <tr>
+        <td>
+          {% if z.wyslano %}
+          <i class="bi bi-check-lg text-success"></i>
+          {% endif %}
+        </td>
         <td>{{ z.data.date() }}</td>
         <td>{{ z.czas_trwania }}</td>
         <td>{{ z.obecni|length }}/{{ z.prowadzacy.uczestnicy|length }}</td>
@@ -178,11 +183,6 @@
               <span class="visually-hidden">Usuń zajęcia</span>
             </button>
           </form>
-        </td>
-        <td>
-          {% if z.wyslano %}
-          <i class="bi bi-check-lg text-success"></i>
-          {% endif %}
         </td>
       </tr>
       {% endfor %}


### PR DESCRIPTION
## Summary
- reorder 'Wysłano' before 'Data' in panel history table
- reorder 'Wysłano' before 'Data' on admin dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485117f720832aba26e2accdb3c69e