### PR TITLE
Add graceful email worker shutdown

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -111,8 +111,9 @@ def test_send_plain_email_queue(monkeypatch):
         'b',
         queue=True,
     )
-    utils._email_queue.join()
+    utils.shutdown_email_worker()
     assert called.get('to') == 'x@example.com'
+    assert utils._worker is None or not utils._worker.is_alive()
 
 
 def test_purge_expired_tokens(app):


### PR DESCRIPTION
## Summary
- implement `shutdown_email_worker` and register with `atexit`
- ensure queued messages flush and thread terminates in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68489a7fef24832aa35e2ca11498c458