### PR TITLE
Refactor email sending

### DIFF
--- a/routes/panel.py
+++ b/routes/panel.py
@@ -14,6 +14,7 @@ from utils import (
     SignatureValidationError,
     process_signature,
     email_do_koordynatora,
+    send_attendance_list,
     get_participant_stats,
     get_monthly_summary,
 )
@@ -200,28 +201,9 @@ def wyslij_zajecie(id):
     if not zaj or zaj.prowadzacy_id != current_user.prowadzacy_id:
         abort(403)
 
-    prow = current_user.prowadzacy
-    obecni = [u.imie_nazwisko for u in zaj.obecni]
-    doc = generuj_liste_obecnosci(
-        zaj.data.strftime("%Y-%m-%d"),
-        str(zaj.czas_trwania).replace(".", ","),
-        obecni,
-        f"{prow.imie} {prow.nazwisko}",
-        os.path.join("static", prow.podpis_filename),
-    )
-
-    buf = BytesIO()
-    doc.save(buf)
-    buf.seek(0)
-    data_str = zaj.data.strftime("%Y-%m-%d")
-
-    try:
-        email_do_koordynatora(buf, data_str, typ="lista")
-        zaj.wyslano = True
-        db.session.commit()
+    if send_attendance_list(zaj):
         flash("Lista została wysłana e-mailem", "success")
-    except smtplib.SMTPException:
-        logger.exception("Failed to send attendance email")
+    else:
         flash("Nie udało się wysłać e-maila", "danger")
 
     return redirect(url_for("routes.panel"))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -409,18 +409,15 @@ def test_wyslij_zajecie_success(client, app, monkeypatch):
     with app.app_context():
         zaj_id = Zajecia.query.first().id
 
-    def dummy_list(*_a, **_k):
-        doc = Document()
-        doc.add_paragraph("x")
-        return doc
-
     called = {}
 
-    def fake_email(buf, data, typ=None):
+    def fake_send(z):
         called["sent"] = True
+        z.wyslano = True
+        db.session.commit()
+        return True
 
-    monkeypatch.setattr("routes.panel.generuj_liste_obecnosci", dummy_list)
-    monkeypatch.setattr("routes.panel.email_do_koordynatora", fake_email)
+    monkeypatch.setattr("routes.panel.send_attendance_list", fake_send)
 
     client.post(
         "/login", data={"login": login_val, "hasło": "pass"}, follow_redirects=False
@@ -459,18 +456,15 @@ def test_wyslij_zajecie_admin_success(client, app, monkeypatch):
         db.session.commit()
         zaj_id = Zajecia.query.first().id
 
-    def dummy_list(*_a, **_k):
-        doc = Document()
-        doc.add_paragraph("x")
-        return doc
-
     called = {}
 
-    def fake_email(buf, data, typ=None):
+    def fake_send(z):
         called["sent"] = True
+        z.wyslano = True
+        db.session.commit()
+        return True
 
-    monkeypatch.setattr("routes.admin.generuj_liste_obecnosci", dummy_list)
-    monkeypatch.setattr("routes.admin.email_do_koordynatora", fake_email)
+    monkeypatch.setattr("routes.admin.send_attendance_list", fake_send)
 
     client.post(
         "/login",


### PR DESCRIPTION
## Summary
- create `send_attendance_list` helper in `utils`
- refactor routes to use the helper
- cover helper in new unit tests
- update route tests to patch helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68489c627058832a9dd878e2cd48f3a2