### PR TITLE
Update participants display to table

### DIFF
--- a/templates/panel.html
+++ b/templates/panel.html
@@ -126,29 +126,39 @@
       <a href="{{ url_for('routes.panel', edit=1) }}" class="btn btn-outline-primary">Edytuj</a>
     </div>
 
-    <ul class="list-group mb-3">
-      {% for u in uczestnicy %}
-      <li class="list-group-item">
-        <div class="d-flex align-items-center justify-content-between">
-          <span class="flex-grow-1">{{ u.imie_nazwisko }}</span>
-          <div class="d-flex align-items-center ms-3" style="min-width: 180px;">
-            <div class="progress flex-grow-1 me-2" style="height: 6px;">
-              {# <50% red, 50-79% yellow, >=80% green #}
-              <div
-                class="progress-bar {% if stats[u.id].percent >= 80 %}bg-success{% elif stats[u.id].percent >= 50 %}bg-warning{% else %}bg-danger{% endif %}"
-                role="progressbar"
-                style="width: {{ stats[u.id].percent }}%"
-                aria-valuenow="{{ stats[u.id].percent }}"
-                aria-valuemin="0"
-                aria-valuemax="100"
-              ></div>
+    <table class="table table-striped table-hover mb-3">
+      <thead class="table-secondary">
+        <tr>
+          <th>Uczestnik</th>
+          <th>Frekwencja %</th>
+          <th>Obecności</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for u in uczestnicy %}
+        <tr>
+          <td>{{ u.imie_nazwisko }}</td>
+          <td>
+            <div class="d-flex align-items-center" style="min-width: 180px;">
+              <div class="progress flex-grow-1 me-2" style="height: 6px;">
+                {# <50% red, 50-79% yellow, >=80% green #}
+                <div
+                  class="progress-bar {% if stats[u.id].percent >= 80 %}bg-success{% elif stats[u.id].percent >= 50 %}bg-warning{% else %}bg-danger{% endif %}"
+                  role="progressbar"
+                  style="width: {{ stats[u.id].percent }}%"
+                  aria-valuenow="{{ stats[u.id].percent }}"
+                  aria-valuemin="0"
+                  aria-valuemax="100"
+                ></div>
+              </div>
+              <small class="text-nowrap">{{ '%.0f'|format(stats[u.id].percent) }}%</small>
             </div>
-            <small class="text-nowrap">{{ '%.0f'|format(stats[u.id].percent) }}% {{ stats[u.id].present }}/{{ total_sessions }}</small>
-          </div>
-        </div>
-      </li>
-      {% endfor %}
-    </ul>
+          </td>
+          <td>{{ stats[u.id].present }}/{{ total_sessions }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
   {% endif %}
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -926,6 +926,8 @@ def test_panel_progress_and_edit_forms(client, trainer):
     assert resp.status_code == 200
     html = resp.data.decode()
     assert "progress-bar" in html
+    assert "Frekwencja %" in html
+    assert "<table" in html
 
     resp2 = client.get("/panel?edit=1")
     assert resp2.status_code == 200


### PR DESCRIPTION
## Summary
- display participants in a table instead of a list on the panel page
- check for table headers along with progress bars in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68497644f750832ab1b4e42aaa3d7d89