### PR TITLE
Add shutdown worker test

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,6 +117,22 @@ def test_send_plain_email_queue(monkeypatch):
     assert called.get('to') == 'x@example.com'
     assert utils._worker is None or not utils._worker.is_alive()
 
+def test_shutdown_email_worker_thread(monkeypatch):
+    utils.shutdown_email_worker()
+    monkeypatch.setattr(utils, "_send_message", lambda msg: None)
+    utils.send_plain_email(
+        "y@example.com",
+        "SUBJ",
+        "BODY",
+        "s",
+        "b",
+        queue=True,
+    )
+    assert utils._worker is not None and utils._worker.is_alive()
+    utils.shutdown_email_worker()
+    assert utils._worker is None or not utils._worker.is_alive()
+
+
 
 def test_purge_expired_tokens(app):
     with app.app_context():


### PR DESCRIPTION
## Summary
- check that shutdown_email_worker stops the background thread when queueing emails

## Testing
- `pytest tests/test_utils.py::test_shutdown_email_worker_thread -q`
- `pytest -q` *(fails: KeyboardInterrupt due to shutdown worker at exit)*

------
https://chatgpt.com/codex/tasks/task_e_68497f89d810832a99815e6cddd3e4e6