### PR TITLE
Add Jinja filter for month names

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,12 @@ from dotenv import load_dotenv
 import logging
 import os
 from model import db, Uzytkownik, Prowadzacy, Zajecia
-from utils import load_db_settings, purge_expired_tokens, email_do_koordynatora
+from utils import (
+    load_db_settings,
+    purge_expired_tokens,
+    email_do_koordynatora,
+    month_name,
+)
 from doc_generator import generuj_raport_miesieczny
 from io import BytesIO
 import smtplib
@@ -80,6 +85,7 @@ def create_app():
     app.register_blueprint(routes_bp)
 
     app.context_processor(inject_is_admin)
+    app.add_template_filter(month_name, "month_name")
 
     @app.cli.command("purge-tokens")
     def purge_tokens_command() -> None:

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -176,7 +176,7 @@
       {% for (rok, miesiac), godziny in podsumowanie|dictsort(reverse=True) %}
       <tr>
         <td>{{ rok }}</td>
-        <td>{{ '%02d'|format(miesiac) }}</td>
+        <td>{{ miesiac|month_name }}</td>
         <td>{{ godziny }}</td>
         <td class="action-col text-nowrap">
           <a href="{{ url_for('routes.panel_raport') }}?rok={{ rok }}&miesiac={{ miesiac }}" class="btn btn-sm text-primary" aria-label="Pobierz" title="Pobierz">

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -206,3 +206,11 @@ def test_send_attendance_list_failure(app, monkeypatch):
 
         assert utils.send_attendance_list(zaj) is False
         assert zaj.wyslano is False
+
+
+def test_month_name_filter_registered(app):
+    """The month_name Jinja filter should return Polish month names."""
+    filt = app.jinja_env.filters.get("month_name")
+    assert filt is not None
+    assert filt(1) == "styczeń"
+    assert filt("12") == "grudzień"

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -25,6 +25,30 @@ logger = logging.getLogger(__name__)
 
 EMAIL_REGEX = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
+# Polish month names indexed by number
+MONTH_NAMES_PL = {
+    1: "styczeń",
+    2: "luty",
+    3: "marzec",
+    4: "kwiecień",
+    5: "maj",
+    6: "czerwiec",
+    7: "lipiec",
+    8: "sierpień",
+    9: "wrzesień",
+    10: "październik",
+    11: "listopad",
+    12: "grudzień",
+}
+
+
+def month_name(value):
+    """Return the Polish name of the month ``value``."""
+    try:
+        return MONTH_NAMES_PL[int(value)]
+    except (KeyError, ValueError, TypeError):
+        return ""
+
 # simple asynchronous e-mail dispatch
 _email_queue: "queue.Queue[EmailMessage | None]" = queue.Queue()
 _worker: threading.Thread | None = None


### PR DESCRIPTION
## Summary
- create Polish month name map and Jinja filter
- expose the filter in `create_app`
- use the filter in monthly report table
- verify filter through new unit test

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684995f30c88832ab4284ab4a8a4e59d