### PR TITLE
Add column width classes and update tables

### DIFF
--- a/static/theme.css
+++ b/static/theme.css
@@ -31,3 +31,17 @@ body.high-contrast .btn {
   width: 1%;
   white-space: nowrap;
 }
+
+/* Consistent column widths across tables */
+.id-col {
+  width: 6ch;
+}
+
+.name-col {
+  width: 20ch;
+}
+
+.participants-col {
+  width: 12ch;
+  text-align: center;
+}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -6,18 +6,18 @@
   <table class="table table-bordered align-middle">
     <thead class="table-warning">
       <tr>
-        <th>ID</th>
+        <th class="id-col">ID</th>
         <th>Login</th>
-        <th>Imię i nazwisko</th>
+        <th class="name-col">Imię i nazwisko</th>
         <th class="action-col text-nowrap">Akcja</th>
       </tr>
     </thead>
     <tbody>
       {% for u in new_users %}
       <tr>
-        <td>{{ u.id }}</td>
+        <td class="id-col">{{ u.id }}</td>
         <td>{{ u.login }}</td>
-        <td>{{ u.prowadzacy.imie }} {{ u.prowadzacy.nazwisko }}</td>
+        <td class="name-col">{{ u.prowadzacy.imie }} {{ u.prowadzacy.nazwisko }}</td>
         <td class="action-col text-nowrap">
           <form action="{{ url_for('routes.approve_user', id=u.id) }}" method="POST" class="d-inline">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -49,18 +49,18 @@
   <table class="table table-striped table-bordered align-middle">
     <thead class="table-dark">
       <tr>
-        <th>ID</th>
-        <th>Imię i nazwisko</th>
+        <th class="id-col">ID</th>
+        <th class="name-col">Imię i nazwisko</th>
         <th>Podpis</th>
-        <th>Uczestnicy</th>
-        <th>Akcje</th>
+        <th class="participants-col">Uczestnicy</th>
+        <th class="action-col">Akcje</th>
       </tr>
     </thead>
     <tbody>
       {% for p in prowadzacy %}
       <tr>
-        <td>{{ p.id }}</td>
-        <td>{{ p.imie }} {{ p.nazwisko }}</td>
+        <td class="id-col">{{ p.id }}</td>
+        <td class="name-col">{{ p.imie }} {{ p.nazwisko }}</td>
         <td>
           {% if p.podpis_filename %}
             <img src="{{ url_for('static', filename=p.podpis_filename) }}" alt="Podpis" style="height: 40px;">
@@ -68,8 +68,8 @@
             Brak
           {% endif %}
         </td>
-        <td>{{ p.uczestnicy|length }}</td>
-        <td class="text-nowrap">
+        <td class="participants-col">{{ p.uczestnicy|length }}</td>
+        <td class="action-col text-nowrap">
           <button class="btn btn-sm" onclick="edytujProwadzacego({{ p.id }}, '{{ p.imie }}', '{{ p.nazwisko }}', '{{ p.numer_umowy }}')" aria-label="Edytuj prowadzącego" title="Edytuj prowadzącego">
             <i class="bi bi-pencil"></i>
             <span class="visually-hidden">Edytuj prowadzącego</span>
@@ -163,7 +163,7 @@
         <th>Data</th>
         <th>Czas trwania</th>
         <th>Prowadzący</th>
-        <th>Obecni</th>
+        <th class="participants-col">Obecni</th>
         <th class="action-col text-nowrap">Akcja</th>
       </tr>
     </thead>
@@ -178,7 +178,7 @@
         <td>{{ z.data.date() }}</td>
         <td>{{ z.czas_trwania }}</td>
         <td>{{ z.prowadzacy.imie }} {{ z.prowadzacy.nazwisko }}</td>
-        <td>{{ z.obecni|length }}/{{ z.prowadzacy.uczestnicy|length }}</td>
+        <td class="participants-col">{{ z.obecni|length }}/{{ z.prowadzacy.uczestnicy|length }}</td>
         <td class="action-col text-nowrap">
           <a href="{{ url_for('routes.edytuj_zajecie', id=z.id) }}" class="btn btn-sm" aria-label="Edytuj zajęcia" title="Edytuj zajęcia">
             <i class="bi bi-pencil"></i>

--- a/templates/admin_statystyki.html
+++ b/templates/admin_statystyki.html
@@ -5,16 +5,16 @@
   <table class="table table-striped table-hover mb-4">
     <thead class="table-secondary">
       <tr>
-        <th>Uczestnik</th>
-        <th>Obecności</th>
+        <th class="name-col">Uczestnik</th>
+        <th class="participants-col">Obecności</th>
         <th>Frekwencja</th>
       </tr>
     </thead>
     <tbody>
       {% for row in stats %}
       <tr>
-        <td>{{ row.uczestnik.imie_nazwisko }}</td>
-        <td>{{ row.present }}/{{ total_sessions }}</td>
+        <td class="name-col">{{ row.uczestnik.imie_nazwisko }}</td>
+        <td class="participants-col">{{ row.present }}/{{ total_sessions }}</td>
         <td>{{ '%.0f'|format(row.percent) }}%</td>
       </tr>
       {% endfor %}

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -129,15 +129,15 @@
     <table class="table table-striped table-hover mb-3">
       <thead class="table-secondary">
         <tr>
-          <th>Uczestnik</th>
+          <th class="name-col">Uczestnik</th>
           <th>Frekwencja %</th>
-          <th>Obecności</th>
+          <th class="participants-col">Obecności</th>
         </tr>
       </thead>
       <tbody>
         {% for u in uczestnicy %}
         <tr>
-          <td>{{ u.imie_nazwisko }}</td>
+          <td class="name-col">{{ u.imie_nazwisko }}</td>
           <td>
             <div class="d-flex align-items-center" style="min-width: 180px;">
               <div class="progress flex-grow-1 me-2" style="height: 6px;">
@@ -154,7 +154,7 @@
               <small class="text-nowrap">{{ '%.0f'|format(stats[u.id].percent) }}%</small>
             </div>
           </td>
-          <td>{{ stats[u.id].present }}/{{ total_sessions }}</td>
+          <td class="participants-col">{{ stats[u.id].present }}/{{ total_sessions }}</td>
         </tr>
         {% endfor %}
       </tbody>
@@ -200,7 +200,7 @@
         <th>Wysłano</th>
         <th>Data</th>
         <th>Czas</th>
-        <th>Obecni</th>
+        <th class="participants-col">Obecni</th>
         <th class="action-col text-nowrap">Akcja</th>
       </tr>
     </thead>
@@ -214,7 +214,7 @@
         </td>
         <td>{{ z.data.date() }}</td>
         <td>{{ z.czas_trwania }}</td>
-        <td>{{ z.obecni|length }}/{{ z.prowadzacy.uczestnicy|length }}</td>
+        <td class="participants-col">{{ z.obecni|length }}/{{ z.prowadzacy.uczestnicy|length }}</td>
         <td class="action-col text-nowrap">
           <a href="{{ url_for('routes.panel_edytuj_zajecie', id=z.id) }}" class="btn btn-sm" aria-label="Edytuj zajęcia" title="Edytuj zajęcia">
             <i class="bi bi-pencil"></i>

--- a/templates/statystyki.html
+++ b/templates/statystyki.html
@@ -5,16 +5,16 @@
   <table class="table table-striped table-hover mb-4">
     <thead class="table-secondary">
       <tr>
-        <th>Uczestnik</th>
-        <th>Obecności</th>
+        <th class="name-col">Uczestnik</th>
+        <th class="participants-col">Obecności</th>
         <th>Frekwencja</th>
       </tr>
     </thead>
     <tbody>
       {% for row in stats %}
       <tr>
-        <td>{{ row.uczestnik.imie_nazwisko }}</td>
-        <td>{{ row.present }}/{{ total_sessions }}</td>
+        <td class="name-col">{{ row.uczestnik.imie_nazwisko }}</td>
+        <td class="participants-col">{{ row.present }}/{{ total_sessions }}</td>
         <td>{{ '%.0f'|format(row.percent) }}%</td>
       </tr>
       {% endfor %}


### PR DESCRIPTION
## Summary
- add `.id-col`, `.name-col` and `.participants-col` classes in `theme.css`
- apply these classes to table headers/cells in admin and user templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499920f4d8832aa027e3dfd1bed305