### PR TITLE
Add colgroup layout helpers

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -3,7 +3,14 @@
 {% block content %}
   {% if new_users %}
   <h2 class="mb-4">Konta oczekujące na zatwierdzenie</h2>
+  <div class="table-responsive">
   <table class="table table-bordered align-middle">
+    <colgroup>
+      <col class="id-col">
+      <col>
+      <col class="name-col">
+      <col class="action-col">
+    </colgroup>
     <thead class="table-warning">
       <tr>
         <th class="id-col">ID</th>
@@ -31,6 +38,7 @@
       {% endfor %}
     </tbody>
   </table>
+  </div>
   <hr class="my-4">
   {% endif %}
 
@@ -46,7 +54,15 @@
     {% endwith %}
   </div>
 
+  <div class="table-responsive">
   <table class="table table-striped table-bordered align-middle">
+    <colgroup>
+      <col class="id-col">
+      <col class="name-col">
+      <col>
+      <col class="participants-col">
+      <col class="action-col">
+    </colgroup>
     <thead class="table-dark">
       <tr>
         <th class="id-col">ID</th>
@@ -132,6 +148,7 @@
       {% endfor %}
     </tbody>
   </table>
+  </div>
 
   <hr class="my-5">
 
@@ -156,7 +173,16 @@
     </noscript>
   </form>
 
+  <div class="table-responsive">
   <table class="table table-striped table-hover">
+    <colgroup>
+      <col>
+      <col>
+      <col>
+      <col>
+      <col class="participants-col">
+      <col class="action-col">
+    </colgroup>
     <thead class="table-secondary">
       <tr>
         <th>Wysłano</th>
@@ -204,6 +230,7 @@
       {% endfor %}
     </tbody>
   </table>
+  </div>
 
   <nav aria-label="Paginacja" class="mt-3">
     <ul class="pagination">

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -58,7 +58,15 @@
     </form>
   {% else %}
     <div class="mb-5">
+      <div class="table-responsive">
       <table class="table table-bordered w-auto">
+        <colgroup>
+          <col>
+          <col>
+          <col>
+          <col>
+          <col>
+        </colgroup>
         <thead>
           <tr>
             <th>Imię</th>
@@ -87,6 +95,7 @@
           </tr>
         </tbody>
       </table>
+      </div>
     </div>
   {% endif %}
 
@@ -126,7 +135,13 @@
       <a href="{{ url_for('routes.panel', edit=1) }}" class="btn btn-outline-primary">Edytuj</a>
     </div>
 
+    <div class="table-responsive">
     <table class="table table-striped table-hover mb-3">
+      <colgroup>
+        <col class="name-col">
+        <col>
+        <col class="participants-col">
+      </colgroup>
       <thead class="table-secondary">
         <tr>
           <th class="name-col">Uczestnik</th>
@@ -159,11 +174,19 @@
         {% endfor %}
       </tbody>
     </table>
+    </div>
   {% endif %}
 
 
   <h2 class="mb-4">Raporty miesięczne</h2>
+  <div class="table-responsive">
   <table class="table table-striped table-hover mb-5">
+    <colgroup>
+      <col>
+      <col>
+      <col>
+      <col class="action-col">
+    </colgroup>
     <thead class="table-secondary">
       <tr>
         <th>Rok</th>
@@ -192,9 +215,18 @@
       {% endfor %}
     </tbody>
   </table>
+  </div>
 
   <h2 class="mb-4">Historia zajęć</h2>
+  <div class="table-responsive">
   <table class="table table-striped table-hover">
+    <colgroup>
+      <col>
+      <col>
+      <col>
+      <col class="participants-col">
+      <col class="action-col">
+    </colgroup>
     <thead class="table-secondary">
       <tr>
         <th>Wysłano</th>
@@ -240,6 +272,7 @@
       {% endfor %}
     </tbody>
   </table>
+  </div>
 
   <nav aria-label="Paginacja" class="mt-3">
     <ul class="pagination">


### PR DESCRIPTION
## Summary
- define column layouts in admin and panel tables
- wrap tables in responsive containers for small screens

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after showing 53 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68499d3d6eac832aab4df3dddbcf723e