### PR TITLE
Define attendance column style

### DIFF
--- a/static/theme.css
+++ b/static/theme.css
@@ -45,3 +45,8 @@ body.high-contrast .btn {
   width: 12ch;
   text-align: center;
 }
+
+/* Minimum width for attendance progress column */
+.attendance-col {
+  min-width: 120px;
+}

--- a/templates/admin_trainer.html
+++ b/templates/admin_trainer.html
@@ -54,7 +54,7 @@
       <li class="list-group-item">
         <div class="d-flex align-items-center justify-content-between">
           <span class="flex-grow-1">{{ u.imie_nazwisko }}</span>
-          <div class="d-flex align-items-center ms-3" style="min-width: 180px;">
+          <div class="d-flex align-items-center ms-3 attendance-col">
             <div class="progress flex-grow-1 me-2" style="height: 6px;">
               {# <50% red, 50-79% yellow, >=80% green #}
               <div

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -154,7 +154,7 @@
         <tr>
           <td class="name-col">{{ u.imie_nazwisko }}</td>
           <td>
-            <div class="d-flex align-items-center" style="min-width: 180px;">
+            <div class="d-flex align-items-center attendance-col">
               <div class="progress flex-grow-1 me-2" style="height: 6px;">
                 {# <50% red, 50-79% yellow, >=80% green #}
                 <div


### PR DESCRIPTION
## Summary
- set a reusable `.attendance-col` CSS class
- use the new class in panel and admin pages instead of inline width

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a5143ae0832ababa7410215c6d72