### PR TITLE
Add IDs to tables for accessibility

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -4,7 +4,7 @@
   {% if new_users %}
   <h2 class="mb-4">Konta oczekujące na zatwierdzenie</h2>
   <div class="table-responsive">
-  <table class="table table-bordered align-middle">
+  <table class="table table-bordered align-middle" id="admin-new-users">
     <colgroup>
       <col class="id-col col-admin-new_users-id">
       <col class="col-admin-new_users-login">
@@ -55,7 +55,7 @@
   </div>
 
   <div class="table-responsive">
-  <table class="table table-striped table-bordered align-middle">
+  <table class="table table-striped table-bordered align-middle" id="admin-trainers">
     <colgroup>
       <col class="id-col col-admin-trainers-id">
       <col class="name-col col-admin-trainers-name">
@@ -174,7 +174,7 @@
   </form>
 
   <div class="table-responsive">
-  <table class="table table-striped table-hover">
+  <table class="table table-striped table-hover" id="admin-history">
     <colgroup>
       <col class="col-admin-sessions-sent">
       <col class="col-admin-sessions-date">

--- a/templates/admin_statystyki.html
+++ b/templates/admin_statystyki.html
@@ -2,7 +2,7 @@
 {% block title %}Statystyki{% endblock %}
 {% block content %}
   <h2 class="mb-4">Statystyki obecności - {{ prowadzacy.imie }} {{ prowadzacy.nazwisko }}</h2>
-  <table class="table table-striped table-hover mb-4">
+  <table class="table table-striped table-hover mb-4" id="admin-stats">
     <thead class="table-secondary">
       <tr>
         <th class="name-col col-admin-stats-name">Uczestnik</th>

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -59,7 +59,7 @@
   {% else %}
     <div class="mb-5">
       <div class="table-responsive">
-      <table class="table table-bordered w-auto">
+      <table class="table table-bordered w-auto" id="panel-profile-data">
         <colgroup>
           <col>
           <col>
@@ -136,7 +136,7 @@
     </div>
 
     <div class="table-responsive">
-    <table class="table table-striped table-hover mb-3">
+    <table class="table table-striped table-hover mb-3" id="panel-participants">
       <colgroup>
         <col class="name-col">
         <col>
@@ -180,7 +180,7 @@
 
   <h2 class="mb-4">Raporty miesięczne</h2>
   <div class="table-responsive">
-  <table class="table table-striped table-hover mb-5">
+  <table class="table table-striped table-hover mb-5" id="panel-monthly-reports">
     <colgroup>
       <col>
       <col>
@@ -219,7 +219,7 @@
 
   <h2 class="mb-4">Historia zajęć</h2>
   <div class="table-responsive">
-  <table class="table table-striped table-hover">
+  <table class="table table-striped table-hover" id="panel-history">
     <colgroup>
       <col>
       <col>

--- a/templates/statystyki.html
+++ b/templates/statystyki.html
@@ -2,7 +2,7 @@
 {% block title %}Statystyki{% endblock %}
 {% block content %}
   <h2 class="mb-4">Statystyki obecności</h2>
-  <table class="table table-striped table-hover mb-4">
+  <table class="table table-striped table-hover mb-4" id="stats">
     <thead class="table-secondary">
       <tr>
         <th class="name-col">Uczestnik</th>


### PR DESCRIPTION
## Summary
- add descriptive IDs to admin tables
- add descriptive IDs to panel tables
- add descriptive IDs for statistics pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c390c7ac832a99fdd20c2a8cf7d3