### PR TITLE
Handle per-table width settings

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1001,10 +1001,9 @@ def test_save_column_widths(client, app):
     )
     assert resp.status_code == 302
     with app.app_context():
-        setting = Setting.query.get("table_column_widths")
+        setting = Setting.query.get("table_admin_trainers_widths")
         assert setting is not None
-        data = json.loads(setting.value)
-        assert data["admin_trainers"]["name"] == 30
+        assert setting.value == "name=30.0"
 
 
 def test_admin_page_contains_width_class(client, app):


### PR DESCRIPTION
## Summary
- save column widths separately for each table
- store width data in `table_<table>_widths` settings
- update tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849c7697340832aa0aa76a7504e76b1