### PR TITLE
Add inline table width mapping

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -5,11 +5,12 @@
   <h2 class="mb-4">Konta oczekujące na zatwierdzenie</h2>
   <div class="table-responsive">
   <table class="table table-bordered align-middle" id="admin-new-users">
+    {% set w = table_widths.get('admin-new-users', []) %}
     <colgroup>
-      <col class="id-col col-admin-new_users-id">
-      <col class="col-admin-new_users-login">
-      <col class="name-col col-admin-new_users-name">
-      <col class="action-col col-admin-new_users-action">
+      <col class="id-col col-admin-new_users-id"{% if w|length > 0 %} style="width: {{ w[0] }}%"{% endif %}>
+      <col class="col-admin-new_users-login"{% if w|length > 1 %} style="width: {{ w[1] }}%"{% endif %}>
+      <col class="name-col col-admin-new_users-name"{% if w|length > 2 %} style="width: {{ w[2] }}%"{% endif %}>
+      <col class="action-col col-admin-new_users-action"{% if w|length > 3 %} style="width: {{ w[3] }}%"{% endif %}>
     </colgroup>
     <thead class="table-warning">
       <tr>
@@ -56,12 +57,13 @@
 
   <div class="table-responsive">
   <table class="table table-striped table-bordered align-middle" id="admin-trainers">
+    {% set w = table_widths.get('admin-trainers', []) %}
     <colgroup>
-      <col class="id-col col-admin-trainers-id">
-      <col class="name-col col-admin-trainers-name">
-      <col class="col-admin-trainers-signature">
-      <col class="participants-col col-admin-trainers-participants">
-      <col class="action-col col-admin-trainers-action">
+      <col class="id-col col-admin-trainers-id"{% if w|length > 0 %} style="width: {{ w[0] }}%"{% endif %}>
+      <col class="name-col col-admin-trainers-name"{% if w|length > 1 %} style="width: {{ w[1] }}%"{% endif %}>
+      <col class="col-admin-trainers-signature"{% if w|length > 2 %} style="width: {{ w[2] }}%"{% endif %}>
+      <col class="participants-col col-admin-trainers-participants"{% if w|length > 3 %} style="width: {{ w[3] }}%"{% endif %}>
+      <col class="action-col col-admin-trainers-action"{% if w|length > 4 %} style="width: {{ w[4] }}%"{% endif %}>
     </colgroup>
     <thead class="table-dark">
       <tr>
@@ -175,13 +177,14 @@
 
   <div class="table-responsive">
   <table class="table table-striped table-hover" id="admin-history">
+    {% set w = table_widths.get('admin-sessions', []) %}
     <colgroup>
-      <col class="col-admin-sessions-sent">
-      <col class="col-admin-sessions-date">
-      <col class="col-admin-sessions-duration">
-      <col class="col-admin-sessions-trainer">
-      <col class="participants-col col-admin-sessions-participants">
-      <col class="action-col col-admin-sessions-action">
+      <col class="col-admin-sessions-sent"{% if w|length > 0 %} style="width: {{ w[0] }}%"{% endif %}>
+      <col class="col-admin-sessions-date"{% if w|length > 1 %} style="width: {{ w[1] }}%"{% endif %}>
+      <col class="col-admin-sessions-duration"{% if w|length > 2 %} style="width: {{ w[2] }}%"{% endif %}>
+      <col class="col-admin-sessions-trainer"{% if w|length > 3 %} style="width: {{ w[3] }}%"{% endif %}>
+      <col class="participants-col col-admin-sessions-participants"{% if w|length > 4 %} style="width: {{ w[4] }}%"{% endif %}>
+      <col class="action-col col-admin-sessions-action"{% if w|length > 5 %} style="width: {{ w[5] }}%"{% endif %}>
     </colgroup>
     <thead class="table-secondary">
       <tr>

--- a/templates/admin_statystyki.html
+++ b/templates/admin_statystyki.html
@@ -3,11 +3,12 @@
 {% block content %}
   <h2 class="mb-4">Statystyki obecności - {{ prowadzacy.imie }} {{ prowadzacy.nazwisko }}</h2>
   <table class="table table-striped table-hover mb-4" id="admin-stats">
+    {% set w = table_widths.get('admin-stats', []) %}
     <thead class="table-secondary">
       <tr>
-        <th class="name-col col-admin-stats-name">Uczestnik</th>
-        <th class="participants-col col-admin-stats-present">Obecności</th>
-        <th class="col-admin-stats-percent">Frekwencja</th>
+        <th class="name-col col-admin-stats-name"{% if w|length > 0 %} style="width: {{ w[0] }}%"{% endif %}>Uczestnik</th>
+        <th class="participants-col col-admin-stats-present"{% if w|length > 1 %} style="width: {{ w[1] }}%"{% endif %}>Obecności</th>
+        <th class="col-admin-stats-percent"{% if w|length > 2 %} style="width: {{ w[2] }}%"{% endif %}>Frekwencja</th>
       </tr>
     </thead>
     <tbody>

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,15 +6,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
   <link href="{{ url_for('static', filename='theme.css') }}" rel="stylesheet">
-  {% block head_extra %}
-  <style id="table-column-widths">
-  {% for tbl, cols in table_widths.items() %}
-    {% for col, w in cols.items() %}
-    .col-{{ tbl }}-{{ col }} { width: {{ w }}%; }
-    {% endfor %}
-  {% endfor %}
-  </style>
-  {% endblock %}
+  {% block head_extra %}{% endblock %}
 </head>
 <body class="bg-light d-flex flex-column min-vh-100">
   <a href="#main" class="visually-hidden-focusable">Przejdź do głównej zawartości</a>

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -220,12 +220,13 @@
   <h2 class="mb-4">Historia zajęć</h2>
   <div class="table-responsive">
   <table class="table table-striped table-hover" id="panel-history">
+    {% set w = table_widths.get('panel-history', []) %}
     <colgroup>
-      <col>
-      <col>
-      <col>
-      <col class="participants-col">
-      <col class="action-col">
+      <col{% if w|length > 0 %} style="width: {{ w[0] }}%"{% endif %}>
+      <col{% if w|length > 1 %} style="width: {{ w[1] }}%"{% endif %}>
+      <col{% if w|length > 2 %} style="width: {{ w[2] }}%"{% endif %}>
+      <col class="participants-col"{% if w|length > 3 %} style="width: {{ w[3] }}%"{% endif %}>
+      <col class="action-col"{% if w|length > 4 %} style="width: {{ w[4] }}%"{% endif %}>
     </colgroup>
     <thead class="table-secondary">
       <tr>

--- a/templates/statystyki.html
+++ b/templates/statystyki.html
@@ -3,11 +3,12 @@
 {% block content %}
   <h2 class="mb-4">Statystyki obecności</h2>
   <table class="table table-striped table-hover mb-4" id="stats">
+    {% set w = table_widths.get('stats', []) %}
     <thead class="table-secondary">
       <tr>
-        <th class="name-col">Uczestnik</th>
-        <th class="participants-col">Obecności</th>
-        <th>Frekwencja</th>
+        <th class="name-col"{% if w|length > 0 %} style="width: {{ w[0] }}%"{% endif %}>Uczestnik</th>
+        <th class="participants-col"{% if w|length > 1 %} style="width: {{ w[1] }}%"{% endif %}>Obecności</th>
+        <th{% if w|length > 2 %} style="width: {{ w[2] }}%"{% endif %}>Frekwencja</th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
## Summary
- parse `table_*_widths` env settings in `load_db_settings`
- drop generated column-width CSS in `base.html`
- set column width styles directly in tables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f74f408c832a94f5941701f680f8