### PR TITLE
Add reset widths feature

### DIFF
--- a/static/theme.js
+++ b/static/theme.js
@@ -181,5 +181,19 @@ function togglePassword(id, btn) {
         });
       });
     }
+
+    const resetButtons = document.querySelectorAll('.reset-widths');
+    resetButtons.forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        const key = btn.getAttribute('data-table');
+        const inputs = document.querySelectorAll('input[data-table="' + key + '"]');
+        if (!inputs.length) return;
+        const val = 100 / inputs.length;
+        inputs.forEach(function(inp) {
+          inp.value = val;
+          applyWidth(inp);
+        });
+      });
+    });
   });
 })();

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -209,6 +209,7 @@
           </tr>
         </thead>
       </table>
+      <button type="button" class="btn btn-sm text-secondary reset-widths" data-table="{{ table }}">Resetuj</button>
       <span class="ms-2 total-warning" data-table="{{ table }}"></span>
     </div>
     {% endfor %}


### PR DESCRIPTION
## Summary
- allow resetting column widths per table
- hook up JS handler for the reset buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a137afbec832aa07dd6240e528f39