### PR TITLE
Add column width settings for panel participants

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -100,6 +100,7 @@ def admin_settings():
         "table_admin_stats_widths",
         "table_panel_history_widths",
         "table_panel_profile_data_widths",
+        "table_panel_participants_widths",
     ]
 
     if request.method == "POST":

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -140,23 +140,24 @@
     <div class="table-responsive">
     <table class="table table-striped table-hover mb-3" id="panel-participants">
       <caption class="visually-hidden">Uczestnicy</caption>
+      {% set w = table_widths.get('panel-participants', []) %}
       <colgroup>
-        <col class="name-col">
-        <col>
-        <col class="participants-col">
+        <col class="name-col col-panel-participants-name"{% if w|length > 0 %} style="width: {{ w[0] }}%"{% endif %}>
+        <col class="col-panel-participants-percent"{% if w|length > 1 %} style="width: {{ w[1] }}%"{% endif %}>
+        <col class="participants-col col-panel-participants-present"{% if w|length > 2 %} style="width: {{ w[2] }}%"{% endif %}>
       </colgroup>
       <thead class="table-secondary">
         <tr>
-          <th class="name-col">Uczestnik</th>
-          <th>Frekwencja %</th>
-          <th class="participants-col">Obecności</th>
+          <th class="name-col col-panel-participants-name">Uczestnik</th>
+          <th class="col-panel-participants-percent">Frekwencja %</th>
+          <th class="participants-col col-panel-participants-present">Obecności</th>
         </tr>
       </thead>
       <tbody>
         {% for u in uczestnicy %}
         <tr>
-          <td class="name-col">{{ u.imie_nazwisko }}</td>
-          <td>
+          <td class="name-col col-panel-participants-name">{{ u.imie_nazwisko }}</td>
+          <td class="col-panel-participants-percent">
             <div class="d-flex align-items-center attendance-col">
               <div class="progress flex-grow-1 me-2" style="height: 6px;">
                 {# <50% red, 50-79% yellow, >=80% green #}
@@ -172,7 +173,7 @@
               <small class="text-nowrap">{{ '%.0f'|format(stats[u.id].percent) }}%</small>
             </div>
           </td>
-          <td class="participants-col">{{ stats[u.id].present }}/{{ total_sessions }}</td>
+          <td class="participants-col col-panel-participants-present">{{ stats[u.id].present }}/{{ total_sessions }}</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -177,6 +177,15 @@
           ('action', 'Akcja', 'action-col text-nowrap col-panel-history-action'),
         ]
       },
+      'panel_participants': {
+        'class': 'table table-striped table-hover mb-3',
+        'thead': 'table-secondary',
+        'columns': [
+          ('name', 'Uczestnik', 'name-col col-panel-participants-name'),
+          ('percent', 'Frekwencja %', 'col-panel-participants-percent'),
+          ('present', 'Obecności', 'participants-col col-panel-participants-present'),
+        ]
+      },
       'panel_profile_data': {
         'class': 'table table-bordered w-auto',
         'thead': '',
@@ -195,6 +204,7 @@
       'admin_sessions': 'Historia zajęć',
       'admin_stats': 'Statystyki obecności',
       'panel_history': 'Historia zajęć',
+      'panel_participants': 'Uczestnicy',
       'panel_profile_data': 'Moje dane'
     } %}
     {% for table, info in tables.items() %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1004,6 +1004,9 @@ def test_save_column_widths(client, app):
             "width_panel_profile_data_contract": "20",
             "width_panel_profile_data_default": "20",
             "width_panel_profile_data_signature": "20",
+            "width_panel_participants_name": "20",
+            "width_panel_participants_percent": "40",
+            "width_panel_participants_present": "40",
         },
         follow_redirects=False,
     )
@@ -1026,6 +1029,16 @@ def test_save_column_widths(client, app):
         profile = Setting.query.get("table_panel_profile_data_widths")
         assert profile is not None
         assert "first=20.0" in profile.value
+        participants = Setting.query.get("table_panel_participants_widths")
+        assert participants is not None
+        parts_p = {}
+        for item in participants.value.split(','):
+            if not item:
+                continue
+            key, val = item.split('=')
+            parts_p[key] = float(val)
+        assert abs(sum(parts_p.values()) - 100.0) < 0.1
+        assert parts_p.get("percent") == 40.0
 
 
 def test_save_column_widths_invalid_sum(client, app):
@@ -1087,6 +1100,28 @@ def test_panel_profile_widths_render(client, app):
     assert resp.status_code == 200
     html = resp.data.decode()
     assert 'col-panel-profile-data-first" style="width: 10.0%' in html
+
+
+def test_panel_participants_widths_render(client, app):
+    _login_admin(client, app)
+    trainer_login = _create_trainer(app)
+    resp = client.post(
+        "/admin/settings",
+        data={
+            "width_panel_participants_name": "30",
+            "width_panel_participants_percent": "30",
+            "width_panel_participants_present": "40",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    utils.load_db_settings(app)
+    client.get("/logout")
+    client.post("/login", data={"login": trainer_login, "hasło": "pass"})
+    resp = client.get("/panel")
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    assert 'col-panel-participants-name" style="width: 30.0%' in html
 
 
 def test_admin_settings_rejects_bad_widths(client, app):


### PR DESCRIPTION
## Summary
- allow saving widths for "Uczestnicy" table
- hook new setting key in admin route
- support editing panel participant column widths
- test panel participant widths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aae111634832aa78d5ab6001fe41b