### PR TITLE
Fix width of profile data table

### DIFF
--- a/templates/panel.html
+++ b/templates/panel.html
@@ -59,7 +59,7 @@
   {% else %}
     <div class="mb-5">
       <div class="table-responsive">
-      <table class="table table-bordered w-auto" id="panel-profile-data">
+      <table class="table table-bordered w-100" id="panel-profile-data">
         <caption class="visually-hidden">Moje dane</caption>
         {% set w = table_widths.get('panel-profile-data', []) %}
         <colgroup>


### PR DESCRIPTION
## Summary
- use `w-100` for panel profile data table so it spans width of container

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac32427ac832a91db3766531c9510