### PR TITLE
Add table-bordered style

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -222,7 +222,7 @@
   </form>
 
   <div class="table-responsive">
-  <table class="table table-striped table-hover" id="admin-history">
+  <table class="table table-striped table-hover table-bordered" id="admin-history">
     <caption class="visually-hidden">Historia zajęć</caption>
     {% set w = table_widths.get('admin-sessions', []) %}
     <colgroup>

--- a/templates/admin_statystyki.html
+++ b/templates/admin_statystyki.html
@@ -9,7 +9,7 @@
       <a href="{{ url_for('routes.admin_statystyki', trainer_id=prowadzacy.id, edit=1) }}" class="btn btn-outline-primary">Edytuj</a>
     {% endif %}
   </div>
-  <table class="table table-striped table-hover mb-4" id="admin-stats">
+  <table class="table table-striped table-hover table-bordered mb-4" id="admin-stats">
     <caption class="visually-hidden">Statystyki obecności</caption>
     {% set w = table_widths.get('admin-stats', []) %}
     <thead class="table-secondary">

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -138,7 +138,7 @@
     </div>
 
     <div class="table-responsive">
-    <table class="table table-striped table-hover mb-3" id="panel-participants">
+    <table class="table table-striped table-hover table-bordered mb-3" id="panel-participants">
       <caption class="visually-hidden">Uczestnicy</caption>
       {% set w = table_widths.get('panel-participants', []) %}
       <colgroup>
@@ -184,7 +184,7 @@
 
   <h2 class="mb-4">Raporty miesięczne</h2>
   <div class="table-responsive">
-  <table class="table table-striped table-hover mb-5" id="panel-monthly-reports">
+  <table class="table table-striped table-hover table-bordered mb-5" id="panel-monthly-reports">
     <caption class="visually-hidden">Raporty miesięczne</caption>
     {% set w = table_widths.get('panel-monthly-reports', []) %}
     <colgroup>
@@ -232,7 +232,7 @@
     {% endif %}
   </div>
   <div class="table-responsive">
-  <table class="table table-striped table-hover" id="panel-history">
+  <table class="table table-striped table-hover table-bordered" id="panel-history">
     <caption class="visually-hidden">Historia zajęć</caption>
     {% set w = table_widths.get('panel-history', []) %}
     <colgroup>


### PR DESCRIPTION
## Summary
- add `table-bordered` class for history tables and monthly reports
- confirm table appearance in admin and panel views

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac9365cf4832abbc850bf772ae74f