### PR TITLE
Implement dynamic participant input functionality

### DIFF
--- a/static/theme.js
+++ b/static/theme.js
@@ -34,6 +34,32 @@ function togglePassword(id, btn) {
   }
 }
 
+function handleParticipantPaste(e) {
+  const data = (e.clipboardData || window.clipboardData).getData('text');
+  if (data && /[\r\n]/.test(data)) {
+    e.preventDefault();
+    const lines = data.replace(/\r/g, '').split('\n');
+    const first = lines.shift();
+    e.target.value = first;
+    lines.forEach(function(line) { addParticipantField(line); });
+  }
+}
+
+function addParticipantField(value = '') {
+  const container = document.getElementById('participants-container');
+  if (!container) return;
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.name = 'uczestnik';
+  input.required = true;
+  input.placeholder = 'Imię i nazwisko';
+  input.className = 'form-control mb-2 participant-input';
+  input.value = value;
+  input.addEventListener('paste', handleParticipantPaste);
+  container.appendChild(input);
+  return input;
+}
+
 (function() {
   let theme = localStorage.getItem('theme');
   if (!theme) {
@@ -68,6 +94,12 @@ function togglePassword(id, btn) {
         }
       });
     }
+
+    const addBtn = document.getElementById('addParticipant');
+    if (addBtn) addBtn.addEventListener('click', function(){ addParticipantField(); });
+    document.querySelectorAll('.participant-input').forEach(function(inp){
+      inp.addEventListener('paste', handleParticipantPaste);
+    });
 
     const widthInputs = document.querySelectorAll('[data-column]');
 

--- a/templates/register.html
+++ b/templates/register.html
@@ -20,7 +20,7 @@
       <div class="mb-3">
         <label for="participants-container" class="form-label">Lista uczestników:</label>
         <div id="participants-container">
-          <input type="text" class="form-control mb-2" name="uczestnik" placeholder="Imię i nazwisko" required tabindex="4">
+          <input type="text" class="form-control mb-2 participant-input" name="uczestnik" placeholder="Imię i nazwisko" required tabindex="4">
         </div>
         <button type="button" class="btn btn-outline-secondary btn-sm" id="addParticipant" tabindex="-1">Dodaj</button>
         <div class="form-text">Wklejenie wielu linii spowoduje utworzenie tylu pól, ile wierszy.</div>


### PR DESCRIPTION
## Summary
- allow registration form to dynamically add participant fields
- handle multi-line paste events splitting into separate inputs
- wire up Add button click to new `addParticipantField` function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684acf73a7d0832ab514e1cd5f320574