### PR TITLE
Add removable participant groups

### DIFF
--- a/static/theme.js
+++ b/static/theme.js
@@ -48,16 +48,38 @@ function handleParticipantPaste(e) {
 function addParticipantField(value = '') {
   const container = document.getElementById('participants-container');
   if (!container) return;
+  const group = document.createElement('div');
+  group.className = 'participant-group mb-2';
+
   const input = document.createElement('input');
   input.type = 'text';
   input.name = 'uczestnik';
   input.required = true;
   input.placeholder = 'Imię i nazwisko';
-  input.className = 'form-control mb-2 participant-input';
+  input.className = 'form-control participant-input';
   input.value = value;
   input.addEventListener('paste', handleParticipantPaste);
-  container.appendChild(input);
+
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.className = 'btn btn-outline-secondary btn-sm remove-participant ms-2';
+  removeBtn.textContent = 'Usuń';
+  removeBtn.addEventListener('click', function(){ removeParticipantField(removeBtn); });
+
+  group.appendChild(input);
+  group.appendChild(removeBtn);
+  container.appendChild(group);
   return input;
+}
+
+function removeParticipantField(btn) {
+  const group = btn.closest('.participant-group');
+  if (!group) return;
+  const container = document.getElementById('participants-container');
+  if (!container) return;
+  const groups = container.querySelectorAll('.participant-group');
+  if (groups.length <= 1) return;
+  group.remove();
 }
 
 (function() {
@@ -99,6 +121,9 @@ function addParticipantField(value = '') {
     if (addBtn) addBtn.addEventListener('click', function(){ addParticipantField(); });
     document.querySelectorAll('.participant-input').forEach(function(inp){
       inp.addEventListener('paste', handleParticipantPaste);
+    });
+    document.querySelectorAll('.remove-participant').forEach(function(btn){
+      btn.addEventListener('click', function(){ removeParticipantField(btn); });
     });
 
     const widthInputs = document.querySelectorAll('[data-column]');

--- a/templates/register.html
+++ b/templates/register.html
@@ -20,7 +20,10 @@
       <div class="mb-3">
         <label for="participants-container" class="form-label">Lista uczestników:</label>
         <div id="participants-container">
-          <input type="text" class="form-control mb-2 participant-input" name="uczestnik" placeholder="Imię i nazwisko" required tabindex="4">
+          <div class="participant-group mb-2">
+            <input type="text" class="form-control participant-input" name="uczestnik" placeholder="Imię i nazwisko" required tabindex="4">
+            <button type="button" class="btn btn-outline-secondary btn-sm remove-participant ms-2">Usuń</button>
+          </div>
         </div>
         <button type="button" class="btn btn-outline-secondary btn-sm" id="addParticipant" tabindex="-1">Dodaj</button>
         <div class="form-text">Wklejenie wielu linii spowoduje utworzenie tylu pól, ile wierszy.</div>

--- a/tests/run_participants.js
+++ b/tests/run_participants.js
@@ -1,0 +1,18 @@
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+
+let data = '';
+process.stdin.on('data', chunk => data += chunk);
+process.stdin.on('end', () => {
+  const dom = new JSDOM(data, { runScripts: 'dangerously', url: 'http://localhost' });
+  const window = dom.window;
+  const document = window.document;
+  window.matchMedia = window.matchMedia || function(){ return {matches:false, addListener:function(){}, removeListener:function(){}}; };
+  const script = fs.readFileSync('static/theme.js', 'utf8');
+  window.eval(script);
+  document.dispatchEvent(new window.Event('DOMContentLoaded'));
+  const btn = document.querySelector('.remove-participant');
+  if (btn) btn.click();
+  const count = document.querySelectorAll('.participant-group').length;
+  console.log(count.toString());
+});

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1058,6 +1058,27 @@ def _parse_settings_preview(html: str) -> dict:
     return json.loads(proc.stdout.decode())
 
 
+def _simulate_remove(html: str) -> int:
+    proc = subprocess.run(
+        ["node", "tests/run_participants.js"],
+        input=html.encode(),
+        capture_output=True,
+        check=True,
+    )
+    return int(proc.stdout.decode().strip())
+
+
+def test_remove_participant_keeps_one(ensure_jsdom):
+    html = (
+        "<div id='participants-container'>"
+        "<div class='participant-group'><input class='participant-input' name='uczestnik'><button type='button' class='remove-participant'>Usuń</button></div>"
+        "<div class='participant-group'><input class='participant-input' name='uczestnik'><button type='button' class='remove-participant'>Usuń</button></div>"
+        "</div>"
+    )
+    remaining = _simulate_remove(html)
+    assert remaining == 1
+
+
 def test_save_column_widths(client, app):
     _login_admin(client, app)
     resp = client.post(


### PR DESCRIPTION
## Summary
- restructure participant inputs to use `.participant-group` wrapper with remove button
- update `addParticipantField`/`removeParticipantField` in `theme.js`
- add DOM test verifying participant removal leaves at least one input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c200026fc832a875d12bc9e006e5e