### PR TITLE
Implement register form autosave and restore

### DIFF
--- a/static/theme.js
+++ b/static/theme.js
@@ -45,6 +45,67 @@ function handleParticipantPaste(e) {
   }
 }
 
+function saveRegForm(clear) {
+  if (clear === null) {
+    localStorage.removeItem('registerForm');
+    return;
+  }
+  const form = document.querySelector('form');
+  const container = document.getElementById('participants-container');
+  if (!form || !container) return;
+  const data = {};
+  form.querySelectorAll('input').forEach(function(inp) {
+    if (inp.name === 'uczestnik') {
+      if (!data.uczestnik) data.uczestnik = [];
+      data.uczestnik.push(inp.value);
+    } else if (inp.type !== 'file') {
+      if (inp.id) data[inp.id] = inp.value;
+    }
+  });
+  localStorage.setItem('registerForm', JSON.stringify(data));
+}
+
+function loadRegForm() {
+  const form = document.querySelector('form');
+  const container = document.getElementById('participants-container');
+  if (!form || !container) return;
+  const saved = localStorage.getItem('registerForm');
+  if (!saved) return;
+  let data;
+  try { data = JSON.parse(saved); } catch(e) { return; }
+  if (data.imie !== undefined) {
+    const el = document.getElementById('imie');
+    if (el) el.value = data.imie;
+  }
+  if (data.nazwisko !== undefined) {
+    const el = document.getElementById('nazwisko');
+    if (el) el.value = data.nazwisko;
+  }
+  if (data.numer_umowy !== undefined) {
+    const el = document.getElementById('numer_umowy');
+    if (el) el.value = data.numer_umowy;
+  }
+  if (data.login !== undefined) {
+    const el = document.getElementById('login');
+    if (el) el.value = data.login;
+  }
+  if (data.haslo !== undefined) {
+    const el = document.getElementById('haslo');
+    if (el) el.value = data.haslo;
+  }
+  if (Array.isArray(data.uczestnik)) {
+    const groups = container.querySelectorAll('.participant-group');
+    if (groups.length) {
+      const firstInput = groups[0].querySelector('.participant-input');
+      if (firstInput) firstInput.value = data.uczestnik[0] || '';
+      Array.from(groups).slice(1).forEach(function(g){ g.remove(); });
+    }
+    for (let i = 1; i < data.uczestnik.length; i++) {
+      addParticipantField(data.uczestnik[i]);
+    }
+  }
+}
+
 function addParticipantField(value = '') {
   const container = document.getElementById('participants-container');
   if (!container) return;
@@ -69,6 +130,7 @@ function addParticipantField(value = '') {
   group.appendChild(input);
   group.appendChild(removeBtn);
   container.appendChild(group);
+  saveRegForm();
   return input;
 }
 
@@ -80,6 +142,7 @@ function removeParticipantField(btn) {
   const groups = container.querySelectorAll('.participant-group');
   if (groups.length <= 1) return;
   group.remove();
+  saveRegForm();
 }
 
 (function() {
@@ -125,6 +188,7 @@ function removeParticipantField(btn) {
     document.querySelectorAll('.remove-participant').forEach(function(btn){
       btn.addEventListener('click', function(){ removeParticipantField(btn); });
     });
+    loadRegForm();
 
     const widthInputs = document.querySelectorAll('[data-column]');
 
@@ -236,7 +300,9 @@ function removeParticipantField(btn) {
         tableKeys.forEach(function(key){
           adjustLastColumn(key);
         });
+        saveRegForm(null);
       });
+      form.addEventListener('input', function(){ saveRegForm(); });
     }
 
     const resetButtons = document.querySelectorAll('.reset-widths');

--- a/templates/register.html
+++ b/templates/register.html
@@ -26,7 +26,8 @@
           </div>
         </div>
         <button type="button" class="btn btn-outline-secondary btn-sm" id="addParticipant" tabindex="-1">Dodaj</button>
-        <div class="form-text">Wklejenie wielu linii spowoduje utworzenie tylu pól, ile wierszy.</div>
+        <div class="form-text">Wklejenie wielu linii spowoduje utworzenie tylu pól, ile wierszy. Niedokończone dane są zapisywane w przeglądarce.</div>
+        <button type="button" class="btn btn-outline-secondary btn-sm mt-1" onclick="saveRegForm(null)">Wyczyść dane</button>
       </div>
       <div class="form-floating mb-3">
         <input type="email" class="form-control" id="login" name="login" placeholder="Login" required autocomplete="username" tabindex="5">

--- a/tests/run_register_form.js
+++ b/tests/run_register_form.js
@@ -1,0 +1,43 @@
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+
+let data = '';
+process.stdin.on('data', chunk => data += chunk);
+process.stdin.on('end', () => {
+  const html = data;
+  const script = fs.readFileSync('static/theme.js', 'utf8');
+
+  const dom1 = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
+  const w1 = dom1.window;
+  const d1 = w1.document;
+  w1.matchMedia = w1.matchMedia || function(){ return {matches:false, addListener:function(){}, removeListener:function(){}}; };
+  w1.eval(script);
+  d1.dispatchEvent(new w1.Event('DOMContentLoaded'));
+  d1.getElementById('imie').value = 'A';
+  d1.getElementById('nazwisko').value = 'B';
+  d1.getElementById('numer_umowy').value = '1';
+  d1.getElementById('login').value = 'x@example.com';
+  d1.getElementById('haslo').value = 'pass';
+  const p1 = d1.querySelector('.participant-input');
+  if (p1) p1.value = 'P1';
+  w1.addParticipantField('P2');
+  w1.saveRegForm();
+  const stored = w1.localStorage.getItem('registerForm');
+
+  const dom2 = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
+  const w2 = dom2.window;
+  const d2 = w2.document;
+  w2.matchMedia = w2.matchMedia || function(){ return {matches:false, addListener:function(){}, removeListener:function(){}}; };
+  w2.localStorage.setItem('registerForm', stored);
+  w2.eval(script);
+  d2.dispatchEvent(new w2.Event('DOMContentLoaded'));
+  const values = {
+    imie: d2.getElementById('imie').value,
+    nazwisko: d2.getElementById('nazwisko').value,
+    numer: d2.getElementById('numer_umowy').value,
+    login: d2.getElementById('login').value,
+    haslo: d2.getElementById('haslo').value,
+    participants: Array.from(d2.querySelectorAll('.participant-input')).map(n => n.value)
+  };
+  console.log(JSON.stringify(values));
+});

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1067,6 +1067,15 @@ def _simulate_remove(html: str) -> int:
     )
     return int(proc.stdout.decode().strip())
 
+def _simulate_regform(html: str) -> dict:
+    proc = subprocess.run(
+        ["node", "tests/run_register_form.js"],
+        input=html.encode(),
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(proc.stdout.decode())
+
 
 def test_remove_participant_keeps_one(ensure_jsdom):
     html = (
@@ -1077,6 +1086,26 @@ def test_remove_participant_keeps_one(ensure_jsdom):
     )
     remaining = _simulate_remove(html)
     assert remaining == 1
+
+
+def test_load_regform_restores_values(ensure_jsdom):
+    html = (
+        "<form>"
+        "<div id='participants-container'>"
+        "<div class='participant-group'><input class='participant-input' name='uczestnik'><button type='button' class='remove-participant'>Usuń</button></div>"
+        "</div>"
+        "<button type='button' id='addParticipant'>Dodaj</button>"
+        "<input id='imie'><input id='nazwisko'><input id='numer_umowy'>"
+        "<input id='login'><input id='haslo'>"
+        "</form>"
+    )
+    result = _simulate_regform(html)
+    assert result["imie"] == "A"
+    assert result["nazwisko"] == "B"
+    assert result["numer"] == "1"
+    assert result["login"] == "x@example.com"
+    assert result["haslo"] == "pass"
+    assert result["participants"] == ["P1", "P2"]
 
 
 def test_save_column_widths(client, app):


### PR DESCRIPTION
## Summary
- support automatic register form persistence in `theme.js`
- mention saved data and add 'Wyczyść dane' button in register page
- add JS helper `run_register_form.js`
- test that saved values are restored after reload

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c26f30b08832abb629cbd5702e38a