### PR TITLE
Add login heading and subtle background

### DIFF
--- a/static/theme.css
+++ b/static/theme.css
@@ -1,6 +1,7 @@
 body.high-contrast {
   font-size: 1.2em;
-  background-color: #000 !important;
+  background: #000 !important;
+  background-image: none !important;
   color: #fff !important;
 }
 
@@ -13,6 +14,11 @@ body.high-contrast .btn {
   background-color: #ff0 !important;
   color: #000 !important;
   border-color: #ff0 !important;
+}
+
+html[data-bs-theme="light"] body {
+  background-color: #f4f4f8;
+  background-image: linear-gradient(to bottom right, #ffffff, #f4f4f8);
 }
 
 /* Centered login form container */

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,9 +2,6 @@
 {% block title %}Lista obecności{% endblock %}
 {% block head_extra %}
   <style>
-    body {
-      background-color: #f4f4f8;
-    }
     .action-icons button {
       border: none;
       background: none;

--- a/templates/login.html
+++ b/templates/login.html
@@ -15,6 +15,7 @@
 {% block content %}
   <div class="d-flex justify-content-center align-items-center w-100">
     <div class="login-box">
+      <h1 class="h3 mb-3 text-center">ShareOKO</h1>
       <h2 class="mb-4 text-center">Logowanie</h2>
       <form method="POST" action="/login">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">


### PR DESCRIPTION
## Summary
- show app name on login page
- use light gradient background across all pages
- remove custom body background from the index page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d816ba244832abba0099b8d6f8dde