### PR TITLE
Add course name field

### DIFF
--- a/doc_generator.py
+++ b/doc_generator.py
@@ -5,10 +5,13 @@ import os
 
 logger = logging.getLogger(__name__)
 
-def generuj_liste_obecnosci(data, czas, obecni, trener, podpis_path):
+def generuj_liste_obecnosci(data, czas, obecni, trener, podpis_path, nazwa_zajec=None):
     doc = Document("szablon.docx")
 
     for para in doc.paragraphs:
+        if "Lista obecności" in para.text and nazwa_zajec:
+            para.text = f"Lista obecności – {nazwa_zajec}"
+            continue
         if "Data zajęć:" in para.text and "Czas trwania zajęć:" in para.text:
             para.text = f"Data zajęć: {data}    Czas trwania zajęć: {czas}"
 

--- a/migrations/versions/ad54aed01398_add_course_name.py
+++ b/migrations/versions/ad54aed01398_add_course_name.py
@@ -1,0 +1,23 @@
+"""add course name to Prowadzacy
+
+Revision ID: ad54aed01398
+Revises: 9a7f05de6966
+Create Date: 2025-07-15 12:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'ad54aed01398'
+down_revision = '9a7f05de6966'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('prowadzacy') as batch_op:
+        batch_op.add_column(sa.Column('nazwa_zajec', sa.String(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('prowadzacy') as batch_op:
+        batch_op.drop_column('nazwa_zajec')

--- a/model.py
+++ b/model.py
@@ -22,6 +22,7 @@ class Prowadzacy(db.Model):
     imie = db.Column(db.String)
     nazwisko = db.Column(db.String)
     numer_umowy = db.Column(db.String)  # Dodane pole
+    nazwa_zajec = db.Column(db.String)
     podpis_filename = db.Column(db.String)
     domyslny_czas = db.Column(db.Float)
 

--- a/routes/panel.py
+++ b/routes/panel.py
@@ -74,6 +74,7 @@ def panel_update_profile():
     prow.imie = request.form.get("imie")
     prow.nazwisko = request.form.get("nazwisko")
     prow.numer_umowy = request.form.get("numer_umowy")
+    prow.nazwa_zajec = request.form.get("nazwa_zajec")
     czas_val = request.form.get("domyslny_czas", "").strip()
     if czas_val:
         try:

--- a/static/theme.js
+++ b/static/theme.js
@@ -85,6 +85,10 @@ function loadRegForm() {
     const el = document.getElementById('numer_umowy');
     if (el) el.value = data.numer_umowy;
   }
+  if (data.nazwa_zajec !== undefined) {
+    const el = document.getElementById('nazwa_zajec');
+    if (el) el.value = data.nazwa_zajec;
+  }
   if (data.login !== undefined) {
     const el = document.getElementById('login');
     if (el) el.value = data.login;

--- a/templates/_trainer_modal.html
+++ b/templates/_trainer_modal.html
@@ -21,6 +21,10 @@
             <input type="text" class="form-control" id="nowy_umowa" name="nowy_umowa" placeholder="Numer umowy" required tabindex="3">
             <label for="nowy_umowa">Numer umowy:</label>
           </div>
+          <div class="form-floating mb-3">
+            <input type="text" class="form-control" id="nowy_nazwa" name="nowy_nazwa" placeholder="Nazwa zajęć" required tabindex="4">
+            <label for="nowy_nazwa">Nazwa zajęć:</label>
+          </div>
           <!-- List of participants moved to dedicated page -->
           <div class="form-floating mb-3">
             <input class="form-control" type="file" name="nowy_podpis" id="nowy_podpis" accept=".png,.jpg,.jpeg" tabindex="4">

--- a/templates/_trainer_modal_script.html
+++ b/templates/_trainer_modal_script.html
@@ -1,9 +1,10 @@
 <script>
-  function edytujProwadzacego(id, imie, nazwisko, umowa) {
+  function edytujProwadzacego(id, imie, nazwisko, umowa, nazwa) {
     document.getElementById('edit_id').value = id;
     document.getElementById('nowy_imie').value = imie;
     document.getElementById('nowy_nazwisko').value = nazwisko;
     document.getElementById('nowy_umowa').value = umowa;
+    document.getElementById('nowy_nazwa').value = nazwa || '';
     const modal = bootstrap.Modal.getOrCreateInstance(document.getElementById('dodajModal'));
     modal.show();
   }

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -126,7 +126,7 @@
         </td>
         <td class="participants-col col-admin-trainers-participants">{{ p.uczestnicy|length }}</td>
         <td class="action-col text-nowrap col-admin-trainers-action">
-          <button class="btn btn-sm" onclick="edytujProwadzacego({{ p.id }}, '{{ p.imie }}', '{{ p.nazwisko }}', '{{ p.numer_umowy }}')" aria-label="Edytuj prowadzącego" title="Edytuj prowadzącego">
+          <button class="btn btn-sm" onclick="edytujProwadzacego({{ p.id }}, '{{ p.imie }}', '{{ p.nazwisko }}', '{{ p.numer_umowy }}', '{{ p.nazwa_zajec }}')" aria-label="Edytuj prowadzącego" title="Edytuj prowadzącego">
             <i class="bi bi-pencil"></i>
             <span class="visually-hidden">Edytuj prowadzącego</span>
           </button>

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -37,6 +37,10 @@
           <input type="text" class="form-control" id="numer_umowy" name="numer_umowy" value="{{ prowadzacy.numer_umowy }}">
         </div>
         <div class="col-md-4">
+          <label for="nazwa_zajec" class="form-label">Nazwa zajęć:</label>
+          <input type="text" class="form-control" id="nazwa_zajec" name="nazwa_zajec" value="{{ prowadzacy.nazwa_zajec }}">
+        </div>
+        <div class="col-md-4">
           <label for="domyslny_czas" class="form-label">Domyślny czas zajęć:</label>
           <input type="text" class="form-control" id="domyslny_czas" name="domyslny_czas" value="{{ domyslny_czas }}">
         </div>
@@ -66,14 +70,16 @@
           <col class="col-panel-profile-data-first"{% if w|length > 0 %} style="width: {{ w[0] }}%"{% endif %}>
           <col class="col-panel-profile-data-last"{% if w|length > 1 %} style="width: {{ w[1] }}%"{% endif %}>
           <col class="col-panel-profile-data-contract"{% if w|length > 2 %} style="width: {{ w[2] }}%"{% endif %}>
-          <col class="col-panel-profile-data-default"{% if w|length > 3 %} style="width: {{ w[3] }}%"{% endif %}>
-          <col class="col-panel-profile-data-signature"{% if w|length > 4 %} style="width: {{ w[4] }}%"{% endif %}>
+          <col class="col-panel-profile-data-course"{% if w|length > 3 %} style="width: {{ w[3] }}%"{% endif %}>
+          <col class="col-panel-profile-data-default"{% if w|length > 4 %} style="width: {{ w[4] }}%"{% endif %}>
+          <col class="col-panel-profile-data-signature"{% if w|length > 5 %} style="width: {{ w[5] }}%"{% endif %}>
         </colgroup>
         <thead>
           <tr>
             <th class="col-panel-profile-data-first">Imię</th>
             <th class="col-panel-profile-data-last">Nazwisko</th>
             <th class="col-panel-profile-data-contract">Numer umowy</th>
+            <th class="col-panel-profile-data-course">Nazwa zajęć</th>
             <th class="col-panel-profile-data-default">Domyślny czas zajęć</th>
             <th class="col-panel-profile-data-signature">Podpis</th>
           </tr>
@@ -83,6 +89,7 @@
             <td>{{ prowadzacy.imie }}</td>
             <td>{{ prowadzacy.nazwisko }}</td>
             <td>{{ prowadzacy.numer_umowy }}</td>
+            <td>{{ prowadzacy.nazwa_zajec }}</td>
             <td>{{ domyslny_czas }}</td>
             <td>
               {% if prowadzacy.podpis_filename %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -17,6 +17,10 @@
         <input type="text" class="form-control" id="numer_umowy" name="numer_umowy" placeholder="Numer umowy" required tabindex="3">
         <label for="numer_umowy">Numer umowy:</label>
       </div>
+      <div class="form-floating mb-3">
+        <input type="text" class="form-control" id="nazwa_zajec" name="nazwa_zajec" placeholder="Nazwa zajęć" required tabindex="4">
+        <label for="nazwa_zajec">Nazwa zajęć:</label>
+      </div>
       <div class="mb-3">
         <label for="participants-container" class="form-label">Lista uczestników:</label>
         <div id="participants-container">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -203,6 +203,7 @@
           ('first', 'Imię', 'col-panel-profile-data-first'),
           ('last', 'Nazwisko', 'col-panel-profile-data-last'),
           ('contract', 'Numer umowy', 'col-panel-profile-data-contract'),
+          ('course', 'Nazwa zajęć', 'col-panel-profile-data-course'),
           ('default', 'Domyślny czas zajęć', 'col-panel-profile-data-default'),
           ('signature', 'Podpis', 'col-panel-profile-data-signature'),
         ]

--- a/tests/run_register_form.js
+++ b/tests/run_register_form.js
@@ -16,6 +16,7 @@ process.stdin.on('end', () => {
   d1.getElementById('imie').value = 'A';
   d1.getElementById('nazwisko').value = 'B';
   d1.getElementById('numer_umowy').value = '1';
+  d1.getElementById('nazwa_zajec').value = 'Zajęcia';
   d1.getElementById('login').value = 'x@example.com';
   d1.getElementById('haslo').value = 'pass';
   const p1 = d1.querySelector('.participant-input');
@@ -35,6 +36,7 @@ process.stdin.on('end', () => {
     imie: d2.getElementById('imie').value,
     nazwisko: d2.getElementById('nazwisko').value,
     numer: d2.getElementById('numer_umowy').value,
+    nazwa: d2.getElementById('nazwa_zajec').value,
     login: d2.getElementById('login').value,
     haslo: d2.getElementById('haslo').value,
     participants: Array.from(d2.querySelectorAll('.participant-input')).map(n => n.value)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -137,6 +137,7 @@ def test_successful_register(client, app, monkeypatch):
         "imie": "A",
         "nazwisko": "B",
         "numer_umowy": "1",
+        "nazwa_zajec": "Z",
         "uczestnik": ["X"],
         "login": "ok@example.com",
         "haslo": "pass",
@@ -163,6 +164,7 @@ def test_register_with_new_participant_fields(client, app, monkeypatch):
             ("imie", "A"),
             ("nazwisko", "B"),
             ("numer_umowy", "1"),
+            ("nazwa_zajec", "Z"),
             ("uczestnik", "X"),
             ("uczestnik", "Y\nZ"),
             ("login", "new@example.com"),
@@ -331,7 +333,7 @@ def _create_trainer(app):
     """Create a trainer account with one session and return the login."""
     with app.app_context():
         prow = Prowadzacy(
-            imie="T", nazwisko="T", numer_umowy="1", podpis_filename="sig.png"
+            imie="T", nazwisko="T", numer_umowy="1", nazwa_zajec="Z", podpis_filename="sig.png"
         )
         db.session.add(prow)
         db.session.flush()
@@ -978,6 +980,7 @@ def test_panel_profile_post_updates_trainer(client, app, trainer):
         "imie": "Nowe",
         "nazwisko": "Nazwisko",
         "numer_umowy": "99",
+        "nazwa_zajec": "NZ",
         "domyslny_czas": "3",
     }
     resp = client.post("/panel/profil", data=data, follow_redirects=False)
@@ -987,6 +990,7 @@ def test_panel_profile_post_updates_trainer(client, app, trainer):
         assert prow.imie == "Nowe"
         assert prow.nazwisko == "Nazwisko"
         assert prow.numer_umowy == "99"
+        assert prow.nazwa_zajec == "NZ"
         assert prow.domyslny_czas == 3.0
 
 
@@ -1095,7 +1099,7 @@ def test_load_regform_restores_values(ensure_jsdom):
         "<div class='participant-group'><input class='participant-input' name='uczestnik'><button type='button' class='remove-participant'>Usuń</button></div>"
         "</div>"
         "<button type='button' id='addParticipant'>Dodaj</button>"
-        "<input id='imie'><input id='nazwisko'><input id='numer_umowy'>"
+        "<input id='imie'><input id='nazwisko'><input id='numer_umowy'><input id='nazwa_zajec'>"
         "<input id='login'><input id='haslo'>"
         "</form>"
     )
@@ -1103,6 +1107,7 @@ def test_load_regform_restores_values(ensure_jsdom):
     assert result["imie"] == "A"
     assert result["nazwisko"] == "B"
     assert result["numer"] == "1"
+    assert result["nazwa"] == "Zajęcia"
     assert result["login"] == "x@example.com"
     assert result["haslo"] == "pass"
     assert result["participants"] == ["P1", "P2"]
@@ -1123,9 +1128,10 @@ def test_save_column_widths(client, app):
             "width_panel_history_duration": "20",
             "width_panel_history_participants": "20",
             "width_panel_history_action": "20",
-            "width_panel_profile_data_first": "20",
-            "width_panel_profile_data_last": "20",
-            "width_panel_profile_data_contract": "20",
+            "width_panel_profile_data_first": "15",
+            "width_panel_profile_data_last": "15",
+            "width_panel_profile_data_contract": "15",
+            "width_panel_profile_data_course": "15",
             "width_panel_profile_data_default": "20",
             "width_panel_profile_data_signature": "20",
             "width_panel_participants_name": "20",
@@ -1156,7 +1162,7 @@ def test_save_column_widths(client, app):
         assert parts.get("date") == 20.0
         profile = Setting.query.get("table_panel_profile_data_widths")
         assert profile is not None
-        assert "first=20.0" in profile.value
+        assert "course=15.0" in profile.value
         participants = Setting.query.get("table_panel_participants_widths")
         assert participants is not None
         parts_p = {}
@@ -1225,8 +1231,9 @@ def test_panel_profile_widths_render(client, app):
             "width_panel_profile_data_first": "10",
             "width_panel_profile_data_last": "20",
             "width_panel_profile_data_contract": "20",
-            "width_panel_profile_data_default": "30",
-            "width_panel_profile_data_signature": "20",
+            "width_panel_profile_data_course": "20",
+            "width_panel_profile_data_default": "20",
+            "width_panel_profile_data_signature": "10",
         },
         follow_redirects=False,
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -158,7 +158,7 @@ def test_purge_expired_tokens(app):
 
 
 def _create_simple_session():
-    prow = Prowadzacy(imie="T", nazwisko="T", numer_umowy="1", podpis_filename="sig.png")
+    prow = Prowadzacy(imie="T", nazwisko="T", numer_umowy="1", nazwa_zajec="Z", podpis_filename="sig.png")
     db.session.add(prow)
     db.session.flush()
     zaj = Zajecia(prowadzacy_id=prow.id, data=datetime(2023, 5, 1), czas_trwania=1.0)
@@ -224,6 +224,7 @@ def test_parse_registration_form_old_field(app):
             "imie": "A",
             "nazwisko": "B",
             "numer_umowy": "1",
+            "nazwa_zajec": "Z",
             "lista_uczestnikow": "X\nY",
             "login": "u@example.com",
             "haslo": "pass",
@@ -242,6 +243,7 @@ def test_parse_registration_form_new_field(app):
             ("imie", "A"),
             ("nazwisko", "B"),
             ("numer_umowy", "1"),
+            ("nazwa_zajec", "Z"),
             ("uczestnik", "X"),
             ("uczestnik", "Y\nZ"),
             ("login", "u2@example.com"),

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -306,6 +306,7 @@ def send_attendance_list(zajecie, queue: bool = False) -> bool:
         obecni,
         f"{prow.imie} {prow.nazwisko}",
         os.path.join("static", prow.podpis_filename),
+        prow.nazwa_zajec,
     )
 
     buf = BytesIO()
@@ -400,6 +401,7 @@ def parse_registration_form(form, files):
     imie = form.get("imie")
     nazwisko = form.get("nazwisko")
     numer_umowy = form.get("numer_umowy")
+    nazwa_zajec = form.get("nazwa_zajec")
     lista_uczestnikow = form.get("lista_uczestnikow")
     login_val = form.get("login")
     haslo = form.get("haslo")
@@ -417,7 +419,7 @@ def parse_registration_form(form, files):
             continue
         uczestnicy.extend(l.strip() for l in val.splitlines() if l.strip())
 
-    if not all([imie, nazwisko, numer_umowy, login_val, haslo]) or not uczestnicy:
+    if not all([imie, nazwisko, numer_umowy, nazwa_zajec, login_val, haslo]) or not uczestnicy:
         return None, "Wszystkie pola oprócz podpisu są wymagane"
 
     if not is_valid_email(login_val):
@@ -440,6 +442,7 @@ def parse_registration_form(form, files):
         "imie": imie,
         "nazwisko": nazwisko,
         "numer_umowy": numer_umowy,
+        "nazwa_zajec": nazwa_zajec,
         "login": login_val,
         "haslo": haslo,
         "podpis": podpis,
@@ -463,6 +466,7 @@ def create_trainer(data):
         imie=data["imie"],
         nazwisko=data["nazwisko"],
         numer_umowy=data["numer_umowy"],
+        nazwa_zajec=data["nazwa_zajec"],
         podpis_filename=filename,
     )
     db.session.add(prow)


### PR DESCRIPTION
## Summary
- store course name for trainers
- include course name in list generation and email workflows
- add course name inputs to templates and scripts
- send/store column widths for course name
- test coverage for new field
- migration for the new database column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850791b9f4c832a870f38dcc5563864