### PR TITLE
Add course name field to admin modal

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -305,6 +305,7 @@ def dodaj_prowadzacego():
     imie = request.form.get("nowy_imie")
     nazwisko = request.form.get("nowy_nazwisko")
     numer_umowy = request.form.get("nowy_umowa")
+    nazwa_zajec = request.form.get("nazwa_zajec")
     podpis = request.files.get("nowy_podpis")
 
     if not imie or not nazwisko:
@@ -319,8 +320,14 @@ def dodaj_prowadzacego():
         prow.imie = imie
         prow.nazwisko = nazwisko
         prow.numer_umowy = numer_umowy
+        prow.nazwa_zajec = nazwa_zajec
     else:
-        prow = Prowadzacy(imie=imie, nazwisko=nazwisko, numer_umowy=numer_umowy)
+        prow = Prowadzacy(
+            imie=imie,
+            nazwisko=nazwisko,
+            numer_umowy=numer_umowy,
+            nazwa_zajec=nazwa_zajec,
+        )
         db.session.add(prow)
         db.session.flush()
 

--- a/templates/_trainer_modal.html
+++ b/templates/_trainer_modal.html
@@ -22,8 +22,8 @@
             <label for="nowy_umowa">Numer umowy:</label>
           </div>
           <div class="form-floating mb-3">
-            <input type="text" class="form-control" id="nowy_nazwa" name="nowy_nazwa" placeholder="Nazwa zajęć" required tabindex="4">
-            <label for="nowy_nazwa">Nazwa zajęć:</label>
+            <input type="text" class="form-control" id="nazwa_zajec" name="nazwa_zajec" placeholder="Nazwa zajęć" required tabindex="4">
+            <label for="nazwa_zajec">Nazwa zajęć:</label>
           </div>
           <!-- List of participants moved to dedicated page -->
           <div class="form-floating mb-3">

--- a/templates/_trainer_modal_script.html
+++ b/templates/_trainer_modal_script.html
@@ -4,7 +4,7 @@
     document.getElementById('nowy_imie').value = imie;
     document.getElementById('nowy_nazwisko').value = nazwisko;
     document.getElementById('nowy_umowa').value = umowa;
-    document.getElementById('nowy_nazwa').value = nazwa || '';
+    document.getElementById('nazwa_zajec').value = nazwa || '';
     const modal = bootstrap.Modal.getOrCreateInstance(document.getElementById('dodajModal'));
     modal.show();
   }


### PR DESCRIPTION
## Summary
- include `nazwa_zajec` text input in trainer modal
- populate the course name in modal JS helper
- store `nazwa_zajec` in `dodaj_prowadzacego`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685084853fbc832a98773b5d18d0c494