### PR TITLE
Add placeholder buttons for email templates

### DIFF
--- a/static/theme.js
+++ b/static/theme.js
@@ -34,6 +34,18 @@ function togglePassword(id, btn) {
   }
 }
 
+function insertPlaceholder(text) {
+  const active = document.activeElement;
+  if (!active || active.tagName !== 'TEXTAREA') return;
+  const start = active.selectionStart || 0;
+  const end = active.selectionEnd || 0;
+  const value = active.value;
+  active.value = value.slice(0, start) + text + value.slice(end);
+  const pos = start + text.length;
+  active.selectionStart = active.selectionEnd = pos;
+  active.focus();
+}
+
 function handleParticipantPaste(e) {
   const data = (e.clipboardData || window.clipboardData).getData('text');
   if (data && /[\r\n]/.test(data)) {
@@ -164,6 +176,12 @@ function removeParticipantField(btn) {
     if (darkBtn) darkBtn.addEventListener('click', toggleTheme);
     const contrastBtn = document.getElementById('contrastToggle');
     if (contrastBtn) contrastBtn.addEventListener('click', toggleContrast);
+
+    document.querySelectorAll('.placeholder-btn').forEach(function(btn){
+      btn.addEventListener('click', function(){
+        insertPlaceholder(btn.getAttribute('data-value'));
+      });
+    });
 
     const sigInput = document.getElementById('podpis');
     const sigPreview = document.getElementById('podpisPreview');

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -11,6 +11,7 @@
     {% endwith %}
   </div>
   <form method="POST">
+    {% set placeholders = ['{date}', '{course}', '{name}', '{login}', '{link}'] %}
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="row g-3">
       <div class="col-md-6 form-floating">
@@ -74,6 +75,11 @@
           <input type="text" class="form-control" id="email_list_subject" name="email_list_subject" placeholder="Temat" value="{{ values.email_list_subject }}" tabindex="10">
           <label for="email_list_subject">Temat:</label>
         </div>
+        <div class="mb-2">
+          {% for ph in placeholders %}
+          <button type="button" class="btn btn-outline-secondary btn-sm placeholder-btn me-1" data-value="{{ ph }}">{{ ph }}</button>
+          {% endfor %}
+        </div>
         <div class="form-floating mb-3">
           <textarea class="form-control" id="email_list_body" name="email_list_body" placeholder="Treść" style="height: 4rem" tabindex="11">{{ values.email_list_body }}</textarea>
           <label for="email_list_body">Treść:</label>
@@ -83,6 +89,11 @@
         <div class="form-floating mb-3">
           <input type="text" class="form-control" id="email_report_subject" name="email_report_subject" placeholder="Temat" value="{{ values.email_report_subject }}" tabindex="12">
           <label for="email_report_subject">Temat:</label>
+        </div>
+        <div class="mb-2">
+          {% for ph in placeholders %}
+          <button type="button" class="btn btn-outline-secondary btn-sm placeholder-btn me-1" data-value="{{ ph }}">{{ ph }}</button>
+          {% endfor %}
         </div>
         <div class="form-floating mb-3">
           <textarea class="form-control" id="email_report_body" name="email_report_body" placeholder="Treść" style="height: 4rem" tabindex="13">{{ values.email_report_body }}</textarea>
@@ -94,6 +105,11 @@
           <input type="text" class="form-control" id="registration_email_subject" name="registration_email_subject" placeholder="Temat" value="{{ values.registration_email_subject }}" tabindex="14">
           <label for="registration_email_subject">Temat:</label>
         </div>
+        <div class="mb-2">
+          {% for ph in placeholders %}
+          <button type="button" class="btn btn-outline-secondary btn-sm placeholder-btn me-1" data-value="{{ ph }}">{{ ph }}</button>
+          {% endfor %}
+        </div>
         <div class="form-floating mb-3">
           <textarea class="form-control" id="registration_email_body" name="registration_email_body" placeholder="Treść" style="height: 4rem" tabindex="15">{{ values.registration_email_body }}</textarea>
           <label for="registration_email_body">Treść:</label>
@@ -104,6 +120,11 @@
           <input type="text" class="form-control" id="reg_email_subject" name="reg_email_subject" placeholder="Temat" value="{{ values.reg_email_subject }}" tabindex="16">
           <label for="reg_email_subject">Temat:</label>
         </div>
+        <div class="mb-2">
+          {% for ph in placeholders %}
+          <button type="button" class="btn btn-outline-secondary btn-sm placeholder-btn me-1" data-value="{{ ph }}">{{ ph }}</button>
+          {% endfor %}
+        </div>
         <div class="form-floating mb-3">
           <textarea class="form-control" id="reg_email_body" name="reg_email_body" placeholder="Treść" style="height: 4rem" tabindex="17">{{ values.reg_email_body }}</textarea>
           <label for="reg_email_body">Treść:</label>
@@ -113,6 +134,11 @@
         <div class="form-floating mb-3">
           <input type="text" class="form-control" id="reset_email_subject" name="reset_email_subject" placeholder="Temat" value="{{ values.reset_email_subject }}" tabindex="18">
           <label for="reset_email_subject">Temat:</label>
+        </div>
+        <div class="mb-2">
+          {% for ph in placeholders %}
+          <button type="button" class="btn btn-outline-secondary btn-sm placeholder-btn me-1" data-value="{{ ph }}">{{ ph }}</button>
+          {% endfor %}
         </div>
         <div class="form-floating mb-3">
           <textarea class="form-control" id="reset_email_body" name="reset_email_body" placeholder="Treść" style="height: 4rem" tabindex="19">{{ values.reset_email_body }}</textarea>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1330,6 +1330,15 @@ def test_settings_preview_shows_saved_widths(client, app):
     assert result["warn"] == ""
 
 
+def test_settings_page_has_placeholder_buttons(client, app):
+    _login_admin(client, app)
+    resp = client.get("/admin/settings")
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    for ph in ("{date}", "{course}", "{name}", "{login}", "{link}"):
+        assert f'data-value="{ph}"' in html
+
+
 def test_theme_totals_warning_zero_once_valid():
     html = (
         "<table id='admin-trainers'><col id='admin-trainers-id'><col id='admin-trainers-name'></table>"


### PR DESCRIPTION
## Summary
- show placeholder buttons near email textareas in settings
- allow clicking a button to insert the placeholder at the cursor
- test that the placeholder buttons render in the settings page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850890fa010832a9753175ad6aac86c