### PR TITLE
Handle signature replacement cleanup

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -349,6 +349,14 @@ def dodaj_prowadzacego():
         except Exception:
             flash("Nie udało się przetworzyć obrazu podpisu", "danger")
             return redirect(url_for("routes.admin_dashboard"))
+        if prow.podpis_filename:
+            old_path = os.path.join("static", prow.podpis_filename)
+            try:
+                os.remove(old_path)
+            except FileNotFoundError:
+                pass
+            except Exception:
+                logger.exception("Failed to remove old signature file: %s", old_path)
         prow.podpis_filename = filename
 
     db.session.commit()

--- a/routes/panel.py
+++ b/routes/panel.py
@@ -102,6 +102,14 @@ def panel_update_profile():
         except Exception:
             flash("Nie udało się przetworzyć obrazu podpisu", "danger")
             return redirect(url_for("routes.panel"))
+        if prow.podpis_filename:
+            old_path = os.path.join("static", prow.podpis_filename)
+            try:
+                os.remove(old_path)
+            except FileNotFoundError:
+                pass
+            except Exception:
+                logger.exception("Failed to remove old signature file: %s", old_path)
         prow.podpis_filename = filename
 
     db.session.commit()


### PR DESCRIPTION
## Summary
- delete old signature files before saving new ones
- test that trainer and admin routes remove old files

## Testing
- `pytest tests/test_app.py::test_panel_signature_replace_removes_old_file -q`
- `pytest tests/test_app.py::test_admin_replace_signature_deletes_old_file -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68509a456454832a92d1e7663eeaa608