### PR TITLE
Handle old signature file removal errors

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -354,7 +354,7 @@ def dodaj_prowadzacego():
             try:
                 os.remove(old_path)
             except FileNotFoundError:
-                pass
+                logger.warning("Old signature file not found: %s", old_path)
             except Exception:
                 logger.exception("Failed to remove old signature file: %s", old_path)
         prow.podpis_filename = filename

--- a/routes/panel.py
+++ b/routes/panel.py
@@ -107,7 +107,7 @@ def panel_update_profile():
             try:
                 os.remove(old_path)
             except FileNotFoundError:
-                pass
+                logger.warning("Old signature file not found: %s", old_path)
             except Exception:
                 logger.exception("Failed to remove old signature file: %s", old_path)
         prow.podpis_filename = filename


### PR DESCRIPTION
## Summary
- log missing signature files when updating profile or trainer info
- test coverage already ensures old files are removed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685930a76e3c832aba5af5abec5460f1