### PR TITLE
Improve email customization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ EMAIL_PASSWORD=pass
 MAX_SIGNATURE_SIZE=1048576
 REMOVE_SIGNATURE_BG=0
 EMAIL_SENDER_NAME=Vest Media
+USE_TRAINER_SENDER_NAME=0
 EMAIL_FOOTER="Pozdrawiamy"
 REG_EMAIL_SUBJECT=Aktywacja konta w ShareOKO
 REG_EMAIL_BODY="Twoje konto zostało zatwierdzone i jest już aktywne."

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Copy `.env.example` to `.env` and adjust the values, or export them manually:
   - `EMAIL_LOGIN` – SMTP user name.
   - `EMAIL_PASSWORD` – SMTP password.
   - `EMAIL_SENDER_NAME` – name used in the *From* header.
+  - `USE_TRAINER_SENDER_NAME` – when set to `1`, use the trainer's full name
+    as the *From* header for attendance and report e-mails.
   - `EMAIL_FOOTER` – text appended to every outgoing message.
   - `MAX_SIGNATURE_SIZE` – optional limit for uploaded signature images in bytes (default `1048576`).
   - `REMOVE_SIGNATURE_BG` – when set to `1`, white background is removed from uploaded signatures.

--- a/app.py
+++ b/app.py
@@ -139,7 +139,12 @@ def create_app():
                     doc.save(buf)
                     buf.seek(0)
                     try:
-                        email_do_koordynatora(buf, f"{month}_{year}", typ="raport")
+                        email_do_koordynatora(
+                            buf,
+                            f"{month}_{year}",
+                            typ="raport",
+                            trainer_name=f"{trainer.imie} {trainer.nazwisko}",
+                        )
                         click.echo(f"Sent {filename}")
                     except smtplib.SMTPException:
                         logger.exception("Failed to send report e-mail")

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -83,6 +83,7 @@ def admin_settings():
         "max_signature_size",
         "remove_signature_bg",
         "email_sender_name",
+        "use_trainer_sender_name",
         "email_login",
         "email_password",
         "email_footer",
@@ -108,7 +109,7 @@ def admin_settings():
 
     if request.method == "POST":
         for key in keys:
-            if key == "remove_signature_bg":
+            if key in {"remove_signature_bg", "use_trainer_sender_name"}:
                 val = "1" if request.form.get(key) else "0"
             else:
                 val = request.form.get(key)
@@ -150,7 +151,7 @@ def admin_settings():
             for key in keys:
                 setting = db.session.get(Setting, key)
                 values[key] = os.getenv(key.upper(), setting.value if setting else "")
-                if key == "remove_signature_bg":
+                if key in {"remove_signature_bg", "use_trainer_sender_name"}:
                     if request.form.get(key) is not None:
                         values[key] = "1"
                 elif key in request.form:
@@ -165,7 +166,7 @@ def admin_settings():
             )
 
         for key in keys:
-            if key == "remove_signature_bg":
+            if key in {"remove_signature_bg", "use_trainer_sender_name"}:
                 val = "1" if request.form.get(key) else "0"
             else:
                 val = request.form.get(key)
@@ -282,7 +283,12 @@ def raport(prowadzacy_id):
 
     if wyslij:
         try:
-            email_do_koordynatora(buf, f"{miesiac}_{rok}", typ="raport")
+            email_do_koordynatora(
+                buf,
+                f"{miesiac}_{rok}",
+                typ="raport",
+                trainer_name=f"{prow.imie} {prow.nazwisko}",
+            )
             flash("Raport został wysłany e-mailem", "success")
         except smtplib.SMTPException:
             logger.exception("Failed to send report email")

--- a/routes/attendance.py
+++ b/routes/attendance.py
@@ -77,7 +77,13 @@ def index():
                     )
                 elif akcja == 'wyslij':
                     try:
-                        email_do_koordynatora(buf, data_str, typ='lista')
+                        email_do_koordynatora(
+                            buf,
+                            data_str,
+                            typ='lista',
+                            course=wybrany.nazwa_zajec,
+                            trainer_name=f"{wybrany.imie} {wybrany.nazwisko}",
+                        )
                         flash('Lista została wysłana e-mailem', 'success')
                     except smtplib.SMTPException:
                         logger.exception('Failed to send attendance email')

--- a/routes/panel.py
+++ b/routes/panel.py
@@ -305,7 +305,12 @@ def panel_raport():
 
     if wyslij:
         try:
-            email_do_koordynatora(buf, f"{miesiac}_{rok}", typ="raport")
+            email_do_koordynatora(
+                buf,
+                f"{miesiac}_{rok}",
+                typ="raport",
+                trainer_name=f"{prow.imie} {prow.nazwisko}",
+            )
             flash("Raport został wysłany e-mailem", "success")
         except smtplib.SMTPException:
             logger.exception("Failed to send report email")

--- a/static/theme.js
+++ b/static/theme.js
@@ -322,5 +322,20 @@ function removeParticipantField(btn) {
         });
       });
     });
+
+    document.querySelectorAll('.insert-var').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        const targetId = btn.getAttribute('data-target');
+        const value = btn.getAttribute('data-value');
+        const field = document.getElementById(targetId);
+        if (!field) return;
+        const start = field.selectionStart || field.value.length;
+        const end = field.selectionEnd || start;
+        field.value = field.value.slice(0, start) + value + field.value.slice(end);
+        field.focus();
+        const pos = start + value.length;
+        if (field.setSelectionRange) field.setSelectionRange(pos, pos);
+      });
+    });
   });
 })();

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -37,16 +37,20 @@
         <input type="text" class="form-control" id="email_sender_name" name="email_sender_name" placeholder="Nazwa" value="{{ values.email_sender_name }}" tabindex="6">
         <label for="email_sender_name">Nazwa nadawcy:</label>
       </div>
+      <div class="col-md-6 form-check form-switch">
+        <input class="form-check-input" type="checkbox" id="use_trainer_sender_name" name="use_trainer_sender_name" value="1" {% if values.use_trainer_sender_name.lower() in ['1','true','yes'] %}checked{% endif %} tabindex="7">
+        <label class="form-check-label" for="use_trainer_sender_name">Używaj nazwy prowadzącego jako nadawcy</label>
+      </div>
       <div class="col-md-6 form-floating">
-        <input type="email" class="form-control" id="email_login" name="email_login" placeholder="Login" value="{{ values.email_login }}" tabindex="7" autocomplete="username">
+        <input type="email" class="form-control" id="email_login" name="email_login" placeholder="Login" value="{{ values.email_login }}" tabindex="8" autocomplete="username">
         <label for="email_login">Login SMTP:</label>
       </div>
       <div class="col-md-6 form-floating">
-        <input type="password" class="form-control" id="email_password" name="email_password" placeholder="Hasło" value="{{ values.email_password }}" tabindex="8" autocomplete="current-password">
+        <input type="password" class="form-control" id="email_password" name="email_password" placeholder="Hasło" value="{{ values.email_password }}" tabindex="9" autocomplete="current-password">
         <label for="email_password">Hasło SMTP:</label>
       </div>
       <div class="col-12 form-floating">
-        <textarea class="form-control" id="email_footer" name="email_footer" placeholder="Stopka" style="height: 4rem" tabindex="9">{{ values.email_footer }}</textarea>
+        <textarea class="form-control" id="email_footer" name="email_footer" placeholder="Stopka" style="height: 4rem" tabindex="10">{{ values.email_footer }}</textarea>
         <label for="email_footer">Stopka e-mail:</label>
       </div>
     </div>
@@ -70,9 +74,17 @@
     </ul>
     <div class="tab-content border border-top-0 p-3" id="mailTabsContent">
       <div class="tab-pane fade show active" id="list" role="tabpanel">
+        <div class="mb-1">
+          <button type="button" class="btn btn-outline-secondary btn-sm insert-var" data-target="email_list_subject" data-value="{date}">{date}</button>
+          <button type="button" class="btn btn-outline-secondary btn-sm insert-var" data-target="email_list_subject" data-value="{course}">{course}</button>
+        </div>
         <div class="form-floating mb-3">
           <input type="text" class="form-control" id="email_list_subject" name="email_list_subject" placeholder="Temat" value="{{ values.email_list_subject }}" tabindex="10">
           <label for="email_list_subject">Temat:</label>
+        </div>
+        <div class="mb-1">
+          <button type="button" class="btn btn-outline-secondary btn-sm insert-var" data-target="email_list_body" data-value="{date}">{date}</button>
+          <button type="button" class="btn btn-outline-secondary btn-sm insert-var" data-target="email_list_body" data-value="{course}">{course}</button>
         </div>
         <div class="form-floating mb-3">
           <textarea class="form-control" id="email_list_body" name="email_list_body" placeholder="Treść" style="height: 4rem" tabindex="11">{{ values.email_list_body }}</textarea>
@@ -80,9 +92,15 @@
         </div>
       </div>
       <div class="tab-pane fade" id="report" role="tabpanel">
+        <div class="mb-1">
+          <button type="button" class="btn btn-outline-secondary btn-sm insert-var" data-target="email_report_subject" data-value="{date}">{date}</button>
+        </div>
         <div class="form-floating mb-3">
           <input type="text" class="form-control" id="email_report_subject" name="email_report_subject" placeholder="Temat" value="{{ values.email_report_subject }}" tabindex="12">
           <label for="email_report_subject">Temat:</label>
+        </div>
+        <div class="mb-1">
+          <button type="button" class="btn btn-outline-secondary btn-sm insert-var" data-target="email_report_body" data-value="{date}">{date}</button>
         </div>
         <div class="form-floating mb-3">
           <textarea class="form-control" id="email_report_body" name="email_report_body" placeholder="Treść" style="height: 4rem" tabindex="13">{{ values.email_report_body }}</textarea>
@@ -90,9 +108,19 @@
         </div>
       </div>
       <div class="tab-pane fade" id="registration" role="tabpanel">
+        <div class="mb-1">
+          <button type="button" class="btn btn-outline-secondary btn-sm insert-var" data-target="registration_email_subject" data-value="{name}">{name}</button>
+          <button type="button" class="btn btn-outline-secondary btn-sm insert-var" data-target="registration_email_subject" data-value="{login}">{login}</button>
+          <button type="button" class="btn btn-outline-secondary btn-sm insert-var" data-target="registration_email_subject" data-value="{link}">{link}</button>
+        </div>
         <div class="form-floating mb-3">
           <input type="text" class="form-control" id="registration_email_subject" name="registration_email_subject" placeholder="Temat" value="{{ values.registration_email_subject }}" tabindex="14">
           <label for="registration_email_subject">Temat:</label>
+        </div>
+        <div class="mb-1">
+          <button type="button" class="btn btn-outline-secondary btn-sm insert-var" data-target="registration_email_body" data-value="{name}">{name}</button>
+          <button type="button" class="btn btn-outline-secondary btn-sm insert-var" data-target="registration_email_body" data-value="{login}">{login}</button>
+          <button type="button" class="btn btn-outline-secondary btn-sm insert-var" data-target="registration_email_body" data-value="{link}">{link}</button>
         </div>
         <div class="form-floating mb-3">
           <textarea class="form-control" id="registration_email_body" name="registration_email_body" placeholder="Treść" style="height: 4rem" tabindex="15">{{ values.registration_email_body }}</textarea>
@@ -110,9 +138,15 @@
         </div>
       </div>
       <div class="tab-pane fade" id="reset" role="tabpanel">
+        <div class="mb-1">
+          <button type="button" class="btn btn-outline-secondary btn-sm insert-var" data-target="reset_email_subject" data-value="{link}">{link}</button>
+        </div>
         <div class="form-floating mb-3">
           <input type="text" class="form-control" id="reset_email_subject" name="reset_email_subject" placeholder="Temat" value="{{ values.reset_email_subject }}" tabindex="18">
           <label for="reset_email_subject">Temat:</label>
+        </div>
+        <div class="mb-1">
+          <button type="button" class="btn btn-outline-secondary btn-sm insert-var" data-target="reset_email_body" data-value="{link}">{link}</button>
         </div>
         <div class="form-floating mb-3">
           <textarea class="form-control" id="reset_email_body" name="reset_email_body" placeholder="Treść" style="height: 4rem" tabindex="19">{{ values.reset_email_body }}</textarea>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -422,7 +422,7 @@ def test_panel_raport_email_sending(client, app, monkeypatch):
 
     sent = {}
 
-    def fake_email(buf, data, typ=None, course=None):
+    def fake_email(buf, data, typ=None, course=None, trainer_name=None):
         sent["called"] = True
 
     monkeypatch.setattr("routes.panel.generuj_raport_miesieczny", dummy_report)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,7 +68,7 @@ def test_generate_reports_email(app, monkeypatch, tmp_path):
 
     sent = {}
 
-    def fake_email(buf, data, typ=None, course=None):
+    def fake_email(buf, data, typ=None, course=None, trainer_name=None):
         sent["called"] = True
 
     monkeypatch.setattr("app.generuj_raport_miesieczny", dummy_report)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -250,7 +250,12 @@ def przetworz_liste_obecnosci(form, wybrany):
     return ("success", buf, data_str)
 
 def email_do_koordynatora(
-    buf, data, typ: str = "lista", course: str | None = None, queue: bool = False
+    buf,
+    data,
+    typ: str = "lista",
+    course: str | None = None,
+    trainer_name: str | None = None,
+    queue: bool = False,
 ):
     odbiorca = os.getenv("EMAIL_RECIPIENT")
     if not odbiorca:
@@ -283,7 +288,15 @@ def email_do_koordynatora(
         body = f"{body}\n\n{footer}"
     msg.set_content(body)
 
-    sender_name = os.getenv("EMAIL_SENDER_NAME", "Vest Media")
+    use_trainer = os.getenv("USE_TRAINER_SENDER_NAME", "0").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+    if use_trainer and trainer_name:
+        sender_name = trainer_name
+    else:
+        sender_name = os.getenv("EMAIL_SENDER_NAME", "Vest Media")
     login = os.getenv("EMAIL_LOGIN")
     msg["From"] = f"{sender_name} <{login}>"
     msg["To"] = odbiorca
@@ -330,6 +343,7 @@ def send_attendance_list(zajecie, queue: bool = False) -> bool:
             data_str,
             typ="lista",
             course=prow.nazwa_zajec,
+            trainer_name=f"{prow.imie} {prow.nazwisko}",
             queue=queue,
         )
     except smtplib.SMTPException:
@@ -348,6 +362,7 @@ def send_plain_email(
     default_subject: str,
     default_body: str,
     queue: bool = False,
+    trainer_name: str | None = None,
     **fmt,
 ) -> None:
     """Send a simple text e-mail using templates from environment variables."""
@@ -359,7 +374,15 @@ def send_plain_email(
     if footer:
         body = f"{body}\n\n{footer}"
     msg.set_content(body)
-    sender_name = os.getenv("EMAIL_SENDER_NAME", "Vest Media")
+    use_trainer = os.getenv("USE_TRAINER_SENDER_NAME", "0").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+    if use_trainer and trainer_name:
+        sender_name = trainer_name
+    else:
+        sender_name = os.getenv("EMAIL_SENDER_NAME", "Vest Media")
     login = os.getenv("EMAIL_LOGIN")
     msg["From"] = f"{sender_name} <{login}>"
     msg["To"] = to_addr


### PR DESCRIPTION
## Summary
- allow using trainer name as the From header
- make email template variables clickable
- support new setting USE_TRAINER_SENDER_NAME

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850784abeac832aaf1e84e2672be771